### PR TITLE
WIP: Add support for service accounts

### DIFF
--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -14,23 +14,19 @@ metadata:
   {{- end }}
 data:
   ORG_NAME: {{ .Values.global.orgName | quote }}
+
   {{- if eq .Values.cloud "azure" }}
-  RESPONSE_BUCKET: {{ .Values.objectStorage.azure.storageAccountName | quote }}
-  RESPONSE_BUCKET_PREFIX: {{ .Values.objectStorage.azure.responseContainer | quote }}
-  CODE_BUNDLE_BUCKET: {{ .Values.objectStorage.azure.storageAccountName | quote }}
-  CODE_BUNDLE_BUCKET_PREFIX: {{ .Values.objectStorage.azure.codeBundleContainer | quote }}
-  {{- else }}
+  AZURE_STORAGE_ACCOUNT_NAME: {{ .Values.objectStorage.azure.storageAccountName | quote }}
+  RESPONSE_BUCKET: {{ .Values.objectStorage.azure.responseContainer | quote }}
+  CODE_BUNDLE_BUCKET: {{ .Values.objectStorage.azure.codeBundleContainer | quote }}
+  BRAINSTORE_REALTIME_WAL_BUCKET: {{ .Values.objectStorage.azure.brainstoreContainer | quote }}
+  {{- else if eq .Values.cloud "aws" }}
   RESPONSE_BUCKET: {{ .Values.objectStorage.aws.responseBucket | quote }}
   CODE_BUNDLE_BUCKET: {{ .Values.objectStorage.aws.codeBundleBucket | quote }}
-  {{- end }}
-  ALLOW_CODE_FUNCTION_EXECUTION: {{ .Values.api.allowCodeFunctionExecution | quote }}
-  {{- if eq .Values.cloud "azure" }}
-  BRAINSTORE_REALTIME_WAL_BUCKET: {{ .Values.objectStorage.azure.brainstoreContainer | quote }}
-  BRAINSTORE_REALTIME_WAL_BUCKET_PREFIX: "wal"
-  {{- else }}
   BRAINSTORE_REALTIME_WAL_BUCKET: {{ .Values.objectStorage.aws.brainstoreBucket | quote }}
-  BRAINSTORE_REALTIME_WAL_BUCKET_PREFIX: "brainstore/wal"
   {{- end }}
+
+  ALLOW_CODE_FUNCTION_EXECUTION: {{ .Values.api.allowCodeFunctionExecution | quote }}
   BRAINSTORE_ENABLED: "true"
   BRAINSTORE_URL: "http://{{ .Values.brainstore.name }}:{{ .Values.brainstore.service.port }}"
   BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL: {{ .Values.api.enableHistoricalFullBackfill | quote }}

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -4,6 +4,14 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.api.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with (merge .Values.global.labels .Values.api.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.api.annotations.configmap }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   ORG_NAME: {{ .Values.global.orgName | quote }}
   {{- if eq .Values.cloud "azure" }}

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -17,8 +17,8 @@ data:
   {{- end }}
   ALLOW_CODE_FUNCTION_EXECUTION: {{ .Values.api.allowCodeFunctionExecution | quote }}
   {{- if eq .Values.cloud "azure" }}
-  BRAINSTORE_REALTIME_WAL_BUCKET: {{ .Values.objectStorage.azure.storageAccountName | quote }}
-  BRAINSTORE_REALTIME_WAL_BUCKET_PREFIX: "{{ .Values.objectStorage.azure.brainstoreContainer }}/wal"
+  BRAINSTORE_REALTIME_WAL_BUCKET: {{ .Values.objectStorage.azure.brainstoreContainer | quote }}
+  BRAINSTORE_REALTIME_WAL_BUCKET_PREFIX: "wal"
   {{- else }}
   BRAINSTORE_REALTIME_WAL_BUCKET: {{ .Values.objectStorage.aws.brainstoreBucket | quote }}
   BRAINSTORE_REALTIME_WAL_BUCKET_PREFIX: "brainstore/wal"

--- a/braintrust/templates/api-deployment.yaml
+++ b/braintrust/templates/api-deployment.yaml
@@ -3,6 +3,14 @@ kind: Deployment
 metadata:
   name: {{ .Values.api.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with (merge .Values.global.labels .Values.api.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.api.annotations.deployment }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.api.replicas }}
   selector:
@@ -12,10 +20,16 @@ spec:
     metadata:
       labels:
         app: {{ .Values.api.name }}
-      {{- if eq .Values.cloud "azure" }}
+        {{- with (merge .Values.global.labels .Values.api.labels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
+        {{- if eq .Values.cloud "azure" }}
         azure.workload.identity/use: "true"
-      {{- end }}
+        {{- end }}
+        {{- with .Values.api.annotations.pod }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Values.api.serviceAccount.name }}
       containers:
@@ -45,13 +59,6 @@ spec:
                 secretKeyRef:
                   name: braintrust-secrets
                   key: FUNCTION_SECRET_KEY
-            {{- if eq .Values.cloud "azure" }}
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  name: braintrust-secrets
-                  key: AZURE_STORAGE_CONNECTION_STRING
-            {{- end }}
             {{- if .Values.api.extraEnvVars }}
             {{- toYaml .Values.api.extraEnvVars | nindent 12 }}
             {{- end }}

--- a/braintrust/templates/api-deployment.yaml
+++ b/braintrust/templates/api-deployment.yaml
@@ -3,10 +3,6 @@ kind: Deployment
 metadata:
   name: {{ .Values.api.name }}
   namespace: {{ .Values.global.namespace }}
-  {{- if eq .Values.cloud "azure" }}
-  annotations:
-    azure.workload.identity/use: "true"
-  {{- end }}
 spec:
   replicas: {{ .Values.api.replicas }}
   selector:

--- a/braintrust/templates/api-deployment.yaml
+++ b/braintrust/templates/api-deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.api.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- if eq .Values.cloud "azure" }}
+  annotations:
+    azure.workload.identity/use: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.api.replicas }}
   selector:
@@ -12,7 +16,12 @@ spec:
     metadata:
       labels:
         app: {{ .Values.api.name }}
+      {{- if eq .Values.cloud "azure" }}
+      annotations:
+        azure.workload.identity/use: "true"
+      {{- end }}
     spec:
+      serviceAccountName: {{ .Values.api.serviceAccount.name }}
       containers:
         - name: api
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"

--- a/braintrust/templates/api-service.yaml
+++ b/braintrust/templates/api-service.yaml
@@ -3,6 +3,14 @@ kind: Service
 metadata:
   name: {{ .Values.api.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with (merge .Values.global.labels .Values.api.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.api.annotations.service }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: {{ .Values.api.name }}

--- a/braintrust/templates/api-serviceaccount.yaml
+++ b/braintrust/templates/api-serviceaccount.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.api.serviceAccount.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with (merge .Values.global.labels .Values.api.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     {{- if eq .Values.cloud "aws" }}
     eks.amazonaws.com/role-arn: {{ .Values.api.serviceAccount.awsRoleArn }}
@@ -10,4 +14,7 @@ metadata:
     {{- if eq .Values.cloud "azure" }}
     azure.workload.identity/client-id: {{ .Values.api.serviceAccount.azureClientId }}
     azure.workload.identity/use: "true"
+    {{- end }}
+    {{- with .Values.api.annotations.serviceaccount }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/braintrust/templates/api-serviceaccount.yaml
+++ b/braintrust/templates/api-serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.api.serviceAccount.name }}
+  namespace: {{ .Values.global.namespace }}
+  annotations:
+    {{- if eq .Values.cloud "aws" }}
+    eks.amazonaws.com/role-arn: {{ .Values.api.serviceAccount.awsRoleArn }}
+    {{- end }}
+    {{- if eq .Values.cloud "azure" }}
+    azure.workload.identity/client-id: {{ .Values.api.serviceAccount.azureClientId }}
+    {{- end }}

--- a/braintrust/templates/api-serviceaccount.yaml
+++ b/braintrust/templates/api-serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
     {{- end }}
     {{- if eq .Values.cloud "azure" }}
     azure.workload.identity/client-id: {{ .Values.api.serviceAccount.azureClientId }}
+    azure.workload.identity/use: "true"
     {{- end }}

--- a/braintrust/templates/brainstore-configmap.yaml
+++ b/braintrust/templates/brainstore-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.brainstore.name }}
   namespace: {{ .Values.global.namespace }}
 data:
-  BRAINSTORE_VERBOSE: {{ .Values.brainstore.verbose | quote }}
+  BRAINSTORE_VERBOSE: {{ ternary "1" "0" (eq (.Values.brainstore.verbose | toString) "true") | quote }}
   BRAINSTORE_PORT: {{ .Values.brainstore.service.port | quote }}
   BRAINSTORE_CACHE_DIR: {{ .Values.brainstore.cacheDir | quote }}
   BRAINSTORE_OBJECT_STORE_CACHE_MEMORY_LIMIT: {{ .Values.brainstore.objectStoreCacheMemoryLimit | quote }}

--- a/braintrust/templates/brainstore-configmap.yaml
+++ b/braintrust/templates/brainstore-configmap.yaml
@@ -25,4 +25,4 @@ data:
   BRAINSTORE_INDEX_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/index"
   BRAINSTORE_REALTIME_WAL_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/wal"
   {{- end }}
-  NO_COLOR: {{ .Values.brainstore.noColor | quote }}
+  NO_COLOR: "1"

--- a/braintrust/templates/brainstore-configmap.yaml
+++ b/braintrust/templates/brainstore-configmap.yaml
@@ -19,6 +19,7 @@ data:
   BRAINSTORE_OBJECT_STORE_CACHE_MEMORY_LIMIT: {{ .Values.brainstore.objectStoreCacheMemoryLimit | quote }}
   BRAINSTORE_OBJECT_STORE_CACHE_FILE_SIZE: {{ .Values.brainstore.objectStoreCacheFileSize | quote }}
   {{- if eq .Values.cloud "azure" }}
+  AZURE_STORAGE_ACCOUNT_NAME: "{{ .Values.objectStorage.azure.storageAccountName | quote }}"
   BRAINSTORE_INDEX_URI: "az://{{ .Values.objectStorage.azure.storageAccountName }}/{{ .Values.objectStorage.azure.brainstoreContainer }}/index"
   BRAINSTORE_REALTIME_WAL_URI: "az://{{ .Values.objectStorage.azure.storageAccountName }}/{{ .Values.objectStorage.azure.brainstoreContainer }}/wal"
   {{- else }}

--- a/braintrust/templates/brainstore-configmap.yaml
+++ b/braintrust/templates/brainstore-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  BRAINSTORE_VERBOSE: {{ ternary "1" "0" (eq (.Values.brainstore.verbose | toString) "true") | quote }}
+  BRAINSTORE_VERBOSE: {{ (or (eq (toString .Values.brainstore.verbose) "true") (eq (toString .Values.brainstore.verbose) "1")) | ternary "1" "0" | quote }}
   BRAINSTORE_PORT: {{ .Values.brainstore.service.port | quote }}
   BRAINSTORE_CACHE_DIR: {{ .Values.brainstore.cacheDir | quote }}
   BRAINSTORE_OBJECT_STORE_CACHE_MEMORY_LIMIT: {{ .Values.brainstore.objectStoreCacheMemoryLimit | quote }}

--- a/braintrust/templates/brainstore-configmap.yaml
+++ b/braintrust/templates/brainstore-configmap.yaml
@@ -19,7 +19,7 @@ data:
   BRAINSTORE_OBJECT_STORE_CACHE_MEMORY_LIMIT: {{ .Values.brainstore.objectStoreCacheMemoryLimit | quote }}
   BRAINSTORE_OBJECT_STORE_CACHE_FILE_SIZE: {{ .Values.brainstore.objectStoreCacheFileSize | quote }}
   {{- if eq .Values.cloud "azure" }}
-  AZURE_STORAGE_ACCOUNT_NAME: "{{ .Values.objectStorage.azure.storageAccountName | quote }}"
+  AZURE_STORAGE_ACCOUNT_NAME: {{ .Values.objectStorage.azure.storageAccountName | quote }}
   BRAINSTORE_INDEX_URI: "az://{{ .Values.objectStorage.azure.storageAccountName }}/{{ .Values.objectStorage.azure.brainstoreContainer }}/index"
   BRAINSTORE_REALTIME_WAL_URI: "az://{{ .Values.objectStorage.azure.storageAccountName }}/{{ .Values.objectStorage.azure.brainstoreContainer }}/wal"
   {{- else }}

--- a/braintrust/templates/brainstore-configmap.yaml
+++ b/braintrust/templates/brainstore-configmap.yaml
@@ -4,6 +4,14 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.brainstore.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.brainstore.annotations.configmap }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   BRAINSTORE_VERBOSE: {{ ternary "1" "0" (eq (.Values.brainstore.verbose | toString) "true") | quote }}
   BRAINSTORE_PORT: {{ .Values.brainstore.service.port | quote }}

--- a/braintrust/templates/brainstore-deployment.yaml
+++ b/braintrust/templates/brainstore-deployment.yaml
@@ -3,10 +3,6 @@ kind: Deployment
 metadata:
   name: {{ .Values.brainstore.name }}
   namespace: {{ .Values.global.namespace }}
-  {{- if eq .Values.cloud "azure" }}
-  annotations:
-    azure.workload.identity/use: "true"
-  {{- end }}
 spec:
   replicas: {{ .Values.brainstore.replicas }}
   selector:

--- a/braintrust/templates/brainstore-deployment.yaml
+++ b/braintrust/templates/brainstore-deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.brainstore.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- if eq .Values.cloud "azure" }}
+  annotations:
+    azure.workload.identity/use: "true"
+  {{- end }}
 spec:
   replicas: {{ .Values.brainstore.replicas }}
   selector:
@@ -12,7 +16,12 @@ spec:
     metadata:
       labels:
         app: {{ .Values.brainstore.name }}
+      {{- if eq .Values.cloud "azure" }}
+      annotations:
+        azure.workload.identity/use: "true"
+      {{- end }}
     spec:
+      serviceAccountName: {{ .Values.brainstore.serviceAccount.name }}
       containers:
         - name: brainstore
           image: "{{ .Values.brainstore.image.repository }}:{{ .Values.brainstore.image.tag }}"

--- a/braintrust/templates/brainstore-deployment.yaml
+++ b/braintrust/templates/brainstore-deployment.yaml
@@ -3,6 +3,14 @@ kind: Deployment
 metadata:
   name: {{ .Values.brainstore.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.brainstore.annotations.deployment }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.brainstore.replicas }}
   selector:
@@ -12,10 +20,16 @@ spec:
     metadata:
       labels:
         app: {{ .Values.brainstore.name }}
-      {{- if eq .Values.cloud "azure" }}
+        {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
+        {{- if eq .Values.cloud "azure" }}
         azure.workload.identity/use: "true"
-      {{- end }}
+        {{- end }}
+        {{- with .Values.brainstore.annotations.pod }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Values.brainstore.serviceAccount.name }}
       containers:
@@ -52,13 +66,6 @@ spec:
                 secretKeyRef:
                   name: braintrust-secrets
                   key: BRAINSTORE_LICENSE_KEY
-            {{- if eq .Values.cloud "azure" }}
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  name: braintrust-secrets
-                  key: AZURE_STORAGE_CONNECTION_STRING
-            {{- end }}
             {{- if .Values.brainstore.extraEnvVars }}
             {{- toYaml .Values.brainstore.extraEnvVars | nindent 12 }}
             {{- end }}

--- a/braintrust/templates/brainstore-service.yaml
+++ b/braintrust/templates/brainstore-service.yaml
@@ -3,6 +3,14 @@ kind: Service
 metadata:
   name: {{ .Values.brainstore.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.brainstore.annotations.service }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: {{ .Values.brainstore.name }}

--- a/braintrust/templates/brainstore-serviceaccount.yaml
+++ b/braintrust/templates/brainstore-serviceaccount.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.brainstore.serviceAccount.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     {{- if eq .Values.cloud "aws" }}
     eks.amazonaws.com/role-arn: {{ .Values.brainstore.serviceAccount.awsRoleArn }}
@@ -10,4 +14,7 @@ metadata:
     {{- if eq .Values.cloud "azure" }}
     azure.workload.identity/client-id: {{ .Values.brainstore.serviceAccount.azureClientId }}
     azure.workload.identity/use: "true"
+    {{- end }}
+    {{- with .Values.brainstore.annotations.serviceaccount }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/braintrust/templates/brainstore-serviceaccount.yaml
+++ b/braintrust/templates/brainstore-serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
     {{- end }}
     {{- if eq .Values.cloud "azure" }}
     azure.workload.identity/client-id: {{ .Values.brainstore.serviceAccount.azureClientId }}
+    azure.workload.identity/use: "true"
     {{- end }}

--- a/braintrust/templates/brainstore-serviceaccount.yaml
+++ b/braintrust/templates/brainstore-serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.brainstore.serviceAccount.name }}
+  namespace: {{ .Values.global.namespace }}
+  annotations:
+    {{- if eq .Values.cloud "aws" }}
+    eks.amazonaws.com/role-arn: {{ .Values.brainstore.serviceAccount.awsRoleArn }}
+    {{- end }}
+    {{- if eq .Values.cloud "azure" }}
+    azure.workload.identity/client-id: {{ .Values.brainstore.serviceAccount.azureClientId }}
+    {{- end }}

--- a/braintrust/templates/namespace.yaml
+++ b/braintrust/templates/namespace.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- if eq .Values.cloud "azure" }}
     azure.workload.identity/use: "true"
     {{- end }}
-{{- with .Values.global.labels }}
+    {{- with (merge .Values.global.labels .Values.global.labels) }}
     {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- end }}
+  {{- with .Values.global.annotations.namespaces }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/braintrust/templates/namespace.yaml
+++ b/braintrust/templates/namespace.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ .Values.global.namespace }}
   labels:
     name: {{ .Values.global.namespace }}
+    {{- if eq .Values.cloud "azure" }}
+    azure.workload.identity/use: "true"
+    {{- end }}
 {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
 {{- end }}

--- a/braintrust/templates/namespace.yaml
+++ b/braintrust/templates/namespace.yaml
@@ -4,13 +4,13 @@ metadata:
   name: {{ .Values.global.namespace }}
   labels:
     name: {{ .Values.global.namespace }}
-    {{- if eq .Values.cloud "azure" }}
-    azure.workload.identity/use: "true"
-    {{- end }}
     {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.global.namespaceAnnotations }}
   annotations:
+    {{- if eq .Values.cloud "azure" }}
+    azure.workload.identity/use: "true"
+    {{- end }}
+    {{- with .Values.global.namespaceAnnotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}

--- a/braintrust/templates/namespace.yaml
+++ b/braintrust/templates/namespace.yaml
@@ -7,10 +7,10 @@ metadata:
     {{- if eq .Values.cloud "azure" }}
     azure.workload.identity/use: "true"
     {{- end }}
-    {{- with (merge .Values.global.labels .Values.global.labels) }}
+    {{- with .Values.global.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.global.annotations.namespaces }}
+  {{- with .Values.global.namespaceAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/braintrust/templates/secretproviderclass.yaml
+++ b/braintrust/templates/secretproviderclass.yaml
@@ -20,8 +20,7 @@ spec:
       {{- end }}
   parameters:
     usePodIdentity: "false"
-    useVMManagedIdentity: "true"
-    userAssignedIdentityID: "{{ .Values.azureKeyVaultCSI.userAssignedIdentityID }}"
+    useVMManagedIdentity: "false"
     keyvaultName: "{{ .Values.azureKeyVaultCSI.name }}"
     clientID: "{{ .Values.azureKeyVaultCSI.clientID }}"
     tenantId: "{{ .Values.azureKeyVaultCSI.tenantId }}"

--- a/braintrust/templates/secretproviderclass.yaml
+++ b/braintrust/templates/secretproviderclass.yaml
@@ -4,6 +4,10 @@ kind: SecretProviderClass
 metadata:
   name: {{ .Values.azureKeyVaultCSI.name }}
   namespace: {{ .Values.global.namespace }}
+  {{- with .Values.global.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   provider: azure
   secretObjects:

--- a/braintrust/templates/secretproviderclass.yaml
+++ b/braintrust/templates/secretproviderclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.azureKeyVaultCSI }}
+{{- if .Values.azureKeyVaultCSI.enabled }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -32,7 +32,7 @@ api:
     pullPolicy: Always
   service:
     type: ClusterIP
-    port: 3000
+    port: 8000
   serviceAccount:
     name: "braintrust-api"
     # AWS IAM role ARN for accessing S3 buckets

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -2,6 +2,7 @@
 global:
   orgName: "<your org name on Braintrust>"
   namespace: "braintrust"
+  labels: {}
 
 # Cloud provider configuration
 cloud: "aws"  # or "azure"
@@ -25,6 +26,13 @@ objectStorage:
 
 api:
   name: "braintrust-api"
+  labels: {}
+  annotations:
+    configmap: {}
+    deployment: {}
+    service: {}
+    pod: {}
+    serviceaccount: {}
   replicas: 2
   image:
     repository: public.ecr.aws/braintrust/standalone-api
@@ -63,6 +71,13 @@ api:
 # Brainstore configuration
 brainstore:
   name: "brainstore"
+  labels: {}
+  annotations:
+    configmap: {}
+    deployment: {}
+    service: {}
+    pod: {}
+    serviceaccount: {}
   replicas: 1
   image:
     repository: public.ecr.aws/braintrust/brainstore

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -33,6 +33,12 @@ api:
   service:
     type: ClusterIP
     port: 3000
+  serviceAccount:
+    name: "braintrust-api"
+    # AWS IAM role ARN for accessing S3 buckets
+    awsRoleArn: ""
+    # Azure Workload Identity client ID for accessing storage accounts
+    azureClientId: ""
   resources:
     requests:
       cpu: "2"
@@ -65,6 +71,12 @@ brainstore:
   service:
     type: ClusterIP
     port: 4000
+  serviceAccount:
+    name: "brainstore"
+    # AWS IAM role ARN for accessing S3 buckets
+    awsRoleArn: ""
+    # Azure Workload Identity client ID for accessing storage accounts
+    azureClientId: ""
   resources:
     requests:
       cpu: "8"

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -2,6 +2,7 @@
 global:
   orgName: "<your org name on Braintrust>"
   namespace: "braintrust"
+  namespaceAnnotations: {}
   labels: {}
 
 # Cloud provider configuration

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -43,9 +43,7 @@ api:
     port: 8000
   serviceAccount:
     name: "braintrust-api"
-    # AWS IAM role ARN for accessing S3 buckets
     awsRoleArn: ""
-    # Azure Workload Identity client ID for accessing storage accounts
     azureClientId: ""
   resources:
     requests:
@@ -88,9 +86,7 @@ brainstore:
     port: 4000
   serviceAccount:
     name: "brainstore"
-    # AWS IAM role ARN for accessing S3 buckets
     awsRoleArn: ""
-    # Azure Workload Identity client ID for accessing storage accounts
     azureClientId: ""
   resources:
     requests:
@@ -102,8 +98,7 @@ brainstore:
   cacheDir: "/mnt/tmp/brainstore"
   objectStoreCacheMemoryLimit: "1Gi"
   objectStoreCacheFileSize: "50Gi"
-  verbose: 1
-  noColor: true
+  verbose: true
   extraEnvVars:
     # Example:
     # - name: MY_ENV_VAR
@@ -120,8 +115,6 @@ azureKeyVaultCSI:
   # If you use our terraform module, this will be "<deployment-name>-kv" with a default value of "braintrust-kv"
   name: "braintrust-kv"
 
-  # User Assigned Identity details for accessing Key Vault
-  userAssignedIdentityID: ""
   clientID: ""
   tenantId: ""
 


### PR DESCRIPTION
Add Service Accounts and fix issues with storage accounts and containers in Azure

Other changes:
* Users can now provide additional labels and annotations to different resources
* IRSA (IAM Roles for Service Accounts) for AWS and Workload Identity is now assumed to be setup in Azure and AWS
* Fix: Brainstore verbose can now be passed anything that evals to true or false (e.g. 1, 0, true, "false")
* noColor is no longer an option. There is no case where we want colored logging in k8s.
* AZURE_STORAGE_ACCOUNT_NAME is now passed rather than a connection string. This enables workload identity auth in azure.