### PR TITLE
Remove storage account from azure urls

### DIFF
--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -25,7 +25,7 @@ data:
   CODE_BUNDLE_BUCKET: {{ .Values.objectStorage.aws.codeBundleBucket | quote }}
   BRAINSTORE_REALTIME_WAL_BUCKET: {{ .Values.objectStorage.aws.brainstoreBucket | quote }}
   {{- end }}
-  
+
   ALLOW_CODE_FUNCTION_EXECUTION: {{ .Values.api.allowCodeFunctionExecution | quote }}
   BRAINSTORE_ENABLED: "true"
   BRAINSTORE_URL: "http://{{ .Values.brainstore.name }}:{{ .Values.brainstore.service.port }}"

--- a/braintrust/templates/brainstore-configmap.yaml
+++ b/braintrust/templates/brainstore-configmap.yaml
@@ -19,9 +19,13 @@ data:
   BRAINSTORE_OBJECT_STORE_CACHE_MEMORY_LIMIT: {{ .Values.brainstore.objectStoreCacheMemoryLimit | quote }}
   BRAINSTORE_OBJECT_STORE_CACHE_FILE_SIZE: {{ .Values.brainstore.objectStoreCacheFileSize | quote }}
   {{- if eq .Values.cloud "azure" }}
+  # See here for reference:
+  # https://docs.rs/object_store/latest/object_store/azure/struct.MicrosoftAzureBuilder.html
   AZURE_STORAGE_ACCOUNT_NAME: {{ .Values.objectStorage.azure.storageAccountName | quote }}
-  BRAINSTORE_INDEX_URI: "az://{{ .Values.objectStorage.azure.storageAccountName }}/{{ .Values.objectStorage.azure.brainstoreContainer }}/index"
-  BRAINSTORE_REALTIME_WAL_URI: "az://{{ .Values.objectStorage.azure.storageAccountName }}/{{ .Values.objectStorage.azure.brainstoreContainer }}/wal"
+  # This will create odd paths like az://brainstore/brainstore/index, but it maintains the naming and prefix conventions
+  # with AWS and avoids confusion with env vars.
+  BRAINSTORE_INDEX_URI: "az://{{ .Values.objectStorage.azure.brainstoreContainer }}/brainstore/index"
+  BRAINSTORE_REALTIME_WAL_URI: "az://{{ .Values.objectStorage.azure.brainstoreContainer }}/brainstore/wal"
   {{- else }}
   BRAINSTORE_INDEX_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/index"
   BRAINSTORE_REALTIME_WAL_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/wal"


### PR DESCRIPTION
As documented here: https://docs.rs/object_store/latest/object_store/azure/struct.MicrosoftAzureBuilder.html#method.with_url

Azure `az://` urls are in the form of `az://<container>/<path>`. We had the storage account name in the url which is incorrect. The `AZURE_STORAGE_ACCOUNT_NAME` env var points it at the right storage account.

Note: this will make some odd urls like `az://brainstore/brainstore/wal` but it avoids a lot of configuration confusion of having to customize _PREFIX env vars per cloud.