### PR TITLE
helm: make Service name configurable

### DIFF
--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -29,7 +29,7 @@ data:
 
   ALLOW_CODE_FUNCTION_EXECUTION: {{ .Values.api.allowCodeFunctionExecution | quote }}
   BRAINSTORE_ENABLED: "true"
-  BRAINSTORE_URL: "http://{{ .Values.brainstore.name }}.{{ .Values.global.namespace }}:{{ .Values.brainstore.service.port }}"
+  BRAINSTORE_URL: "http://{{ .Values.brainstore.service.name | default .Values.brainstore.name }}.{{ .Values.global.namespace }}:{{ .Values.brainstore.service.port }}"
   BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL: {{ .Values.api.enableHistoricalFullBackfill | quote }}
   BRAINSTORE_BACKFILL_NEW_OBJECTS: {{ .Values.api.backfillNewObjects | quote }}
   BRAINSTORE_BACKFILL_DISABLE_HISTORICAL: {{ .Values.api.backfillDisableHistorical | quote }}

--- a/braintrust/templates/api-service.yaml
+++ b/braintrust/templates/api-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.api.name }}
+  name: {{ .Values.api.service.name | default .Values.api.name }}
   namespace: {{ .Values.global.namespace }}
   {{- with (merge .Values.global.labels .Values.api.labels) }}
   labels:

--- a/braintrust/templates/brainstore-service.yaml
+++ b/braintrust/templates/brainstore-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.brainstore.name }}
+  name: {{ .Values.brainstore.service.name | default .Values.brainstore.name }}
   namespace: {{ .Values.global.namespace }}
   {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
   labels:

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -41,6 +41,9 @@ api:
     tag: latest
     pullPolicy: Always
   service:
+    # Optional name for service object. If not specified (empty), the api.name
+    # is used.
+    name: ""
     type: ClusterIP
     port: 8000
     portName: http
@@ -86,6 +89,9 @@ brainstore:
     tag: latest
     pullPolicy: Always
   service:
+    # Optional name for service object. If not specified (empty), the
+    # brainstore.name is used.
+    name: ""
     type: ClusterIP
     port: 4000
     portName: http


### PR DESCRIPTION
We need to add additional service objects in our deployment of
braintrust and some flexibility around the name of service objects.

This commit adds two optional values, api.service.name and
brainstore.service.name, for customizing service names. When not
specified, fallback to api.name and brainstore.name for service names.

## Test
- [x] without setting names:

```
helm template braintrust

---
# Source: braintrust/templates/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: braintrust-api
  namespace: braintrust
spec:
  selector:
    app: braintrust-api
  ports:
    - name: http
      protocol: TCP
      port: 8000
      targetPort: 8000
  type: ClusterIP
---
# Source: braintrust/templates/brainstore-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: brainstore
  namespace: braintrust
spec:
  selector:
    app: brainstore
  ports:
    - name: http
      protocol: TCP
      port: 4000
      targetPort: 4000
  type: ClusterIP
```

- [x] with names set
```
helm template braintrust --set api.service.name=braintrust-api-non-mesh --set brainstore.service.name=brainstore-test

# Source: braintrust/templates/api-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: braintrust-api
  namespace: braintrust
data:
  ORG_NAME: "<your org name on Braintrust>"
  RESPONSE_BUCKET: ""
  CODE_BUNDLE_BUCKET: ""
  BRAINSTORE_REALTIME_WAL_BUCKET: ""

  ALLOW_CODE_FUNCTION_EXECUTION: "true"
  BRAINSTORE_ENABLED: "true"
  BRAINSTORE_URL: "http://brainstore-test.braintrust:4000"
  BRAINSTORE_ENABLE_HISTORICAL_FULL_BACKFILL: "true"
  BRAINSTORE_BACKFILL_NEW_OBJECTS: "true"
  BRAINSTORE_BACKFILL_DISABLE_HISTORICAL: "false"
  BRAINSTORE_BACKFILL_DISABLE_NONHISTORICAL: "false"

---
# Source: braintrust/templates/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: braintrust-api-non-mesh
  namespace: braintrust
spec:
  selector:
    app: braintrust-api
  ports:
    - name: http
      protocol: TCP
      port: 8000
      targetPort: 8000
  type: ClusterIP
---
# Source: braintrust/templates/brainstore-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: brainstore-test
  namespace: braintrust
spec:
  selector:
    app: brainstore
  ports:
    - name: http
      protocol: TCP
      port: 4000
      targetPort: 4000
  type: ClusterIP
```

## Reviewers
@mdeeks 