### PR TITLE
Support for locking braintrust services versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
         description: 'Semver version number (e.g., 1.2.3, 1.2.3-alpha.1)'
         required: true
         type: string
+      services_version:
+        description: 'Lock onto Braintrust services version (e.g., v1.2.3). Optional.'
+        required: false
+        type: string
 
 env:
   CHART_PATH: ./braintrust
@@ -39,6 +43,14 @@ jobs:
         run: |
           git config --global user.name "Braintrust Bot"
           git config --global user.email "braintrust-bot@users.noreply.github.com"
+
+      - name: Update versions of Braintrust Services
+        if: inputs.services_version != ''
+        run: |
+          ./lock_versions ${{ inputs.services_version }}
+          git add .
+          git commit -m "Update Braintrust Services versions to ${{ inputs.services_version }}"
+          git push origin main
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -119,6 +131,15 @@ jobs:
         run: |
           # Get the current release notes
           gh release view ${{ github.event.inputs.version }} --json body --jq .body > current_notes.md
+
+          # Add Braintrust Services version information if provided
+          if [ "${{ inputs.services_version }}" != "" ]; then
+            cat >> current_notes.md << EOF
+
+          ## 🔧 Braintrust Services
+          * Updated Braintrust Services to \`${{ inputs.services_version }}\`
+          EOF
+          fi
 
           # Add chart information to release notes
           cat >> current_notes.md << EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,6 @@ jobs:
           git config --global user.name "Braintrust Bot"
           git config --global user.email "braintrust-bot@users.noreply.github.com"
 
-      - name: Update versions of Braintrust Services
-        if: inputs.services_version != ''
-        run: |
-          ./lock_versions ${{ inputs.services_version }}
-          git add .
-          git commit -m "Update Braintrust Services versions to ${{ inputs.services_version }}"
-          git push origin main
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -82,18 +74,24 @@ jobs:
             exit 1
           fi
 
-      - name: Update Chart.yaml version
+      - name: Update versions
         run: |
-          # Fetch main branch and switch to it
+          git config --global user.name "Braintrust Bot"
+          git config --global user.email "215900051+braintrust-bot[bot]@users.noreply.github.com"
           git fetch origin main
           git checkout main
 
-          # Update version in Chart.yaml
-          sed -i "s/^version: .*/version: ${{ github.event.inputs.version }}/" $CHART_PATH/Chart.yaml
+          if [ "${{ inputs.services_version }}" != "" ]; then
+            ./lock_versions ${{ inputs.services_version }}
+            git add .
+            git commit -m "Update Braintrust Services versions to ${{ inputs.services_version }}"
+          fi
 
           # Commit and push the version update
+          sed -i "s/^version: .*/version: ${{ github.event.inputs.version }}/" $CHART_PATH/Chart.yaml
           git add $CHART_PATH/Chart.yaml
-          git commit -m "chore: bump version to ${{ github.event.inputs.version }}"
+          git commit -m "Update Chart version to ${{ github.event.inputs.version }}"
+
           git push origin main
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Configure Git
         run: |
           git config --global user.name "Braintrust Bot"
-          git config --global user.email "braintrust-bot@users.noreply.github.com"
+          git config --global user.email "215900051+braintrust-bot[bot]@users.noreply.github.com"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -76,8 +76,6 @@ jobs:
 
       - name: Update versions
         run: |
-          git config --global user.name "Braintrust Bot"
-          git config --global user.email "215900051+braintrust-bot[bot]@users.noreply.github.com"
           git fetch origin main
           git checkout main
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This repository contains the official Helm chart for deploying Braintrust's self
 ### Install from OCI Registry
 
 ```bash
-helm install braintrust oci://public.ecr.aws/braintrustdata/helm-braintrust-data-plane
+helm install braintrust oci://public.ecr.aws/braintrust/helm/braintrust
 ```
 
 To install a specific version:
 
 ```bash
-helm install braintrust oci://public.ecr.aws/braintrustdata/helm-braintrust-data-plane --version 1.2.3
+helm install braintrust oci://public.ecr.aws/braintrust/helm/braintrust --version 1.2.3
 ```
 
 ## Prerequisites

--- a/lock_versions
+++ b/lock_versions
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv --quiet run --script
+#!/usr/bin/env python3
 import sys
 import re
 

--- a/lock_versions
+++ b/lock_versions
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S uv --quiet run --script
+import sys
+import re
+
+
+def show_help():
+    print(f"Usage: {sys.argv[0]} <version_tag>")
+    print("")
+    print(
+        "Updates container image tags in braintrust/values.yaml to the specified version"
+    )
+    print("")
+    print("Arguments:")
+    print("  version_tag    The version tag to set for both API and Brainstore images")
+    print("")
+    print("Examples:")
+    print(f"  {sys.argv[0]} v1.2.3")
+    print(f"  {sys.argv[0]} 0.9.0")
+    print(f"  {sys.argv[0]} latest")
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] in ["-h", "--help"]:
+        show_help()
+        return
+
+    if len(sys.argv) < 2:
+        print("Error: Please provide a version tag as the first argument")
+        print("")
+        show_help()
+        sys.exit(1)
+
+    version_tag = sys.argv[1]
+    values_file = "braintrust/values.yaml"
+
+    print(f"Updating container image tags to version: {version_tag}")
+
+    try:
+        with open(values_file, "r") as f:
+            content = f.read()
+
+        # This is naive and will replace all tag values with the new version
+        content = re.sub(r"(tag: ).*", r"\1" + version_tag, content)
+        with open(values_file, "w") as f:
+            f.write(content)
+
+    except Exception as e:
+        print(f"Error updating file: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Releases of helm will now lock onto a specific release version of the Braintrust docker containers.

Also, fixed the OCI URLs in the readme