### PR TITLE
Chart no longer creates the namespace by default

### DIFF
--- a/braintrust/templates/_helpers.tpl
+++ b/braintrust/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Get the namespace to use for resources
+*/}}
+{{- define "braintrust.namespace" -}}
+{{- if .Values.global.createNamespace -}}
+{{- .Values.global.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.api.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with (merge .Values.global.labels .Values.api.labels) }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/templates/api-deployment.yaml
+++ b/braintrust/templates/api-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.api.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with (merge .Values.global.labels .Values.api.labels) }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/templates/api-service.yaml
+++ b/braintrust/templates/api-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.api.service.name | default .Values.api.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with (merge .Values.global.labels .Values.api.labels) }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/templates/api-serviceaccount.yaml
+++ b/braintrust/templates/api-serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.api.serviceAccount.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with (merge .Values.global.labels .Values.api.labels) }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/templates/brainstore-configmap.yaml
+++ b/braintrust/templates/brainstore-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.brainstore.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/templates/brainstore-deployment.yaml
+++ b/braintrust/templates/brainstore-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.brainstore.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/templates/brainstore-service.yaml
+++ b/braintrust/templates/brainstore-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.brainstore.service.name | default .Values.brainstore.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/templates/brainstore-serviceaccount.yaml
+++ b/braintrust/templates/brainstore-serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.brainstore.serviceAccount.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with (merge .Values.global.labels .Values.brainstore.labels) }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/templates/secretproviderclass.yaml
+++ b/braintrust/templates/secretproviderclass.yaml
@@ -3,7 +3,7 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: {{ .Values.azureKeyVaultCSI.name }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ include "braintrust.namespace" . }}
   {{- with .Values.global.labels }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -1,7 +1,9 @@
 # Global configs
 global:
   orgName: "<your org name on Braintrust>"
-  createNamespace: true
+  # When createNamespace is true, the namespace will be created and resources will be in global.namespace
+  # When createNamespace is false, resources will use .Release.Namespace (the namespace specified during helm install/upgrade)
+  createNamespace: false
   namespace: "braintrust"
   namespaceAnnotations: {}
   labels: {}


### PR DESCRIPTION
> [!WARNING] 
> This PR changes default behavior and will likely require updating your overrides.

The Helm chart will no longer create a namespace by default. It will instead follow Helm best practices and rely on the user to decide what namespace to use when running helm. 

For example:
```
helm install braintrust oci://public.ecr.aws/braintrust/helm/braintrust --namespace braintrust --create-namespace
# or to use the default namespace 
helm install braintrust oci://public.ecr.aws/braintrust/helm/braintrust
```

Users can maintain the previous default behavior (our chart creates the namespace) by setting `global.createNamespace` to `true`.