### PR TITLE
Release fix: Dont commit if there are no changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,16 +79,25 @@ jobs:
           git fetch origin main
           git checkout main
 
+          # Update services versions if provided
           if [ "${{ inputs.services_version }}" != "" ]; then
             ./lock_versions ${{ inputs.services_version }}
             git add .
-            git commit -m "Update Braintrust Services versions to ${{ inputs.services_version }}"
+            if ! git diff --staged --quiet; then
+              git commit -m "Update Braintrust Services versions to ${{ inputs.services_version }}"
+            else
+              echo "No changes to commit for services version update"
+            fi
           fi
 
-          # Commit and push the version update
+          # Update Chart version
           sed -i "s/^version: .*/version: ${{ github.event.inputs.version }}/" $CHART_PATH/Chart.yaml
           git add $CHART_PATH/Chart.yaml
-          git commit -m "Update Chart version to ${{ github.event.inputs.version }}"
+          if ! git diff --staged --quiet; then
+            git commit -m "Update Chart version to ${{ github.event.inputs.version }}"
+          else
+            echo "No changes to commit for Chart version update"
+          fi
 
           git push origin main
 


### PR DESCRIPTION
Small fix so it doesn't error if you pass in a version number that it is already set to.