### PR TITLE
Enable logs2 and row refs

### DIFF
--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -43,3 +43,6 @@ data:
   BRAINSTORE_BACKFILL_DISABLE_HISTORICAL: {{ .Values.api.backfillDisableHistorical | quote }}
   BRAINSTORE_BACKFILL_DISABLE_NONHISTORICAL: {{ .Values.api.backfillDisableNonhistorical | quote }}
   CONTROL_PLANE_TELEMETRY: {{ .Values.global.controlPlaneTelemetry | quote }}
+  BRAINSTORE_INSERT_ROW_REFS: "true"
+  # Logs v2 table. Requires pg_partman extension (default enabled in our TF modules)
+  INSERT_LOGS2: "true"


### PR DESCRIPTION
Ensure Logs v2 table and row references are enabled. 

Logs2 requires the pg_partman extension in postgres. This is enabled already in our AWS, GCP, and Azure terraform modules.

Row references is a feature that dramatically reduces the size of data stored in the logs table. Data is stored in object storage (S3, etc) and a reference to it is stored in the DB rather than storing the entire contents of the log.

In the near future these will be defaults and wont require setting them explicitly in the helm chart.