### PR TITLE
Do not restrict size of emptyDir

### DIFF
--- a/braintrust/templates/brainstore-reader-deployment.yaml
+++ b/braintrust/templates/brainstore-reader-deployment.yaml
@@ -85,8 +85,7 @@ spec:
             {{- end }}
       volumes:
         - name: cache-volume
-          emptyDir:
-            sizeLimit: {{ .Values.brainstore.reader.objectStoreCacheFileSize | quote }}
+          emptyDir: {}
         {{- if .Values.azureKeyVaultCSI.enabled }}
         - name: secrets-store-inline
           csi:

--- a/braintrust/templates/brainstore-writer-deployment.yaml
+++ b/braintrust/templates/brainstore-writer-deployment.yaml
@@ -85,8 +85,7 @@ spec:
             {{- end }}
       volumes:
         - name: cache-volume
-          emptyDir:
-            sizeLimit: {{ .Values.brainstore.writer.objectStoreCacheFileSize | quote }}
+          emptyDir: {}
         {{- if .Values.azureKeyVaultCSI.enabled }}
         - name: secrets-store-inline
           csi:


### PR DESCRIPTION
The value we pass to brainstore isn't strict enough to keep it under this limit. A customer was seeing evictions for exceeding the limit. 

I'm removing the emptyDir restriction since it isn't completely necessary