### PR TITLE
Add the option to add affinity rules

### DIFF
--- a/braintrust/templates/api-deployment.yaml
+++ b/braintrust/templates/api-deployment.yaml
@@ -40,6 +40,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: api
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"

--- a/braintrust/templates/brainstore-reader-deployment.yaml
+++ b/braintrust/templates/brainstore-reader-deployment.yaml
@@ -46,6 +46,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.brainstore.reader.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: brainstore-reader
           image: "{{ .Values.brainstore.image.repository }}:{{ .Values.brainstore.image.tag }}"

--- a/braintrust/templates/brainstore-writer-deployment.yaml
+++ b/braintrust/templates/brainstore-writer-deployment.yaml
@@ -46,6 +46,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.brainstore.writer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: brainstore-writer
           image: "{{ .Values.brainstore.image.repository }}:{{ .Values.brainstore.image.tag }}"

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -93,6 +93,7 @@ api:
     #   value: "another-value"
   nodeSelector: {}
   tolerations: []
+  affinity: {}
 
 # Brainstore configuration (split into reader and writer)
 brainstore:
@@ -139,6 +140,7 @@ brainstore:
     extraEnvVars: []
     nodeSelector: {}
     tolerations: []
+    affinity: {}
 
   # Brainstore Writer configuration
   writer:
@@ -174,6 +176,7 @@ brainstore:
     #   value: "another-value"
     nodeSelector: {}
     tolerations: []
+    affinity: {}
 
 # Optional Azure Key Vault CSI configuration for syncing secrets from Azure Key Vault
 azureKeyVaultCSI:


### PR DESCRIPTION
Added affinity support to all three deployment templates (api, brainstore-reader, brainstore-writer) allowing users to configure pod anti-affinity rules to spread pods across different nodes in their Kubernetes cluster.