### PR TITLE
Revert "change brainstore locks from redis to object storage"

### DIFF
--- a/braintrust/templates/brainstore-reader-configmap.yaml
+++ b/braintrust/templates/brainstore-reader-configmap.yaml
@@ -27,15 +27,12 @@ data:
   # with AWS and avoids confusion with env vars.
   BRAINSTORE_INDEX_URI: "az://{{ .Values.objectStorage.azure.brainstoreContainer }}/brainstore/index"
   BRAINSTORE_REALTIME_WAL_URI: "az://{{ .Values.objectStorage.azure.brainstoreContainer }}/brainstore/wal"
-  BRAINSTORE_LOCKS_URI: "az://{{ .Values.objectStorage.azure.brainstoreContainer }}/brainstore/locks"
   {{- else if eq .Values.cloud "aws" }}
   BRAINSTORE_INDEX_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/index"
   BRAINSTORE_REALTIME_WAL_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/wal"
-  BRAINSTORE_LOCKS_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/locks"
   {{- else if eq .Values.cloud "google" }}
   BRAINSTORE_INDEX_URI: "gs://{{ .Values.objectStorage.google.brainstoreBucket }}/brainstore/index"
   BRAINSTORE_REALTIME_WAL_URI: "gs://{{ .Values.objectStorage.google.brainstoreBucket }}/brainstore/wal"
-  BRAINSTORE_LOCKS_URI: "gs://{{ .Values.objectStorage.google.brainstoreBucket }}/brainstore/locks"
   {{- end }}
   BRAINSTORE_CONTROL_PLANE_TELEMETRY: {{ .Values.global.controlPlaneTelemetry | quote }}
   NO_COLOR: "1"

--- a/braintrust/templates/brainstore-reader-deployment.yaml
+++ b/braintrust/templates/brainstore-reader-deployment.yaml
@@ -74,6 +74,11 @@ spec:
                 secretKeyRef:
                   name: braintrust-secrets
                   key: PG_URL
+            - name: BRAINSTORE_LOCKS_URI
+              valueFrom:
+                secretKeyRef:
+                  name: braintrust-secrets
+                  key: REDIS_URL
             - name: BRAINSTORE_LICENSE_KEY
               valueFrom:
                 secretKeyRef:

--- a/braintrust/templates/brainstore-writer-configmap.yaml
+++ b/braintrust/templates/brainstore-writer-configmap.yaml
@@ -27,15 +27,12 @@ data:
   # with AWS and avoids confusion with env vars.
   BRAINSTORE_INDEX_URI: "az://{{ .Values.objectStorage.azure.brainstoreContainer }}/brainstore/index"
   BRAINSTORE_REALTIME_WAL_URI: "az://{{ .Values.objectStorage.azure.brainstoreContainer }}/brainstore/wal"
-  BRAINSTORE_LOCKS_URI: "az://{{ .Values.objectStorage.azure.brainstoreContainer }}/brainstore/locks"
   {{- else if eq .Values.cloud "aws" }}
   BRAINSTORE_INDEX_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/index"
   BRAINSTORE_REALTIME_WAL_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/wal"
-  BRAINSTORE_LOCKS_URI: "s3://{{ .Values.objectStorage.aws.brainstoreBucket }}/brainstore/locks"
   {{- else if eq .Values.cloud "google" }}
   BRAINSTORE_INDEX_URI: "gs://{{ .Values.objectStorage.google.brainstoreBucket }}/brainstore/index"
   BRAINSTORE_REALTIME_WAL_URI: "gs://{{ .Values.objectStorage.google.brainstoreBucket }}/brainstore/wal"
-  BRAINSTORE_LOCKS_URI: "gs://{{ .Values.objectStorage.google.brainstoreBucket }}/brainstore/locks"
   {{- end }}
   BRAINSTORE_CONTROL_PLANE_TELEMETRY: {{ .Values.global.controlPlaneTelemetry | quote }}
   NO_COLOR: "1"

--- a/braintrust/templates/brainstore-writer-deployment.yaml
+++ b/braintrust/templates/brainstore-writer-deployment.yaml
@@ -74,6 +74,11 @@ spec:
                 secretKeyRef:
                   name: braintrust-secrets
                   key: PG_URL
+            - name: BRAINSTORE_LOCKS_URI
+              valueFrom:
+                secretKeyRef:
+                  name: braintrust-secrets
+                  key: REDIS_URL
             - name: BRAINSTORE_LICENSE_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Reverts braintrustdata/helm#36

We can't make this change until there is a way to migrate from redis locks to S3 locks