### PR TITLE
Helm chart pod restarts

### DIFF
--- a/braintrust/Chart.yaml
+++ b/braintrust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: braintrust
-version: 3.0.7
+version: 3.0.6
 description: A Helm chart to run the Braintrust services for the self-hosted data plane
 type: application
 home: https://github.com/braintrustdata/helm

--- a/braintrust/Chart.yaml
+++ b/braintrust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: braintrust
-version: 3.0.6
+version: 3.0.7
 description: A Helm chart to run the Braintrust services for the self-hosted data plane
 type: application
 home: https://github.com/braintrustdata/helm

--- a/braintrust/README.md
+++ b/braintrust/README.md
@@ -20,7 +20,7 @@ The `braintrust-secrets` secret must contain the following keys:
 
 ## Scheduled Restarts
 
-By default, the chart creates CronJobs that perform rolling restarts of the API,
+By default, the chart creates a CronJob that performs rolling restarts of the API,
 Brainstore reader, and Brainstore writer Deployments once per hour using
 `kubectl rollout restart`. This keeps restarts graceful and leverages the
 Deployment rolling update strategy.
@@ -30,10 +30,7 @@ You can customize or disable the schedules:
 ```yaml
 scheduledRestart:
   enabled: true
-  schedules:
-    api: "0 * * * *"
-    brainstoreReader: "10 * * * *"
-    brainstoreWriter: "20 * * * *"
+  schedule: "0 * * * *"
   targets:
     brainstoreWriter: false  # Opt out of writer restarts
   image:

--- a/braintrust/README.md
+++ b/braintrust/README.md
@@ -37,11 +37,11 @@ scheduledRestart:
   targets:
     brainstoreWriter: false  # Opt out of writer restarts
   image:
-    tag: "v1.29.6"  # Optional: pin kubectl version
+    repository: "chainguard/kubectl"
+    tag: "latest"  # Optional: pin a specific version
 ```
 
-If `scheduledRestart.image.tag` is left blank, the chart defaults to the
-cluster's Kubernetes version for compatibility.
+Defaults to `chainguard/kubectl:latest` from Docker Hub.
 
 If you already manage RBAC or service accounts, set
 `scheduledRestart.serviceAccount.create` and `scheduledRestart.rbac.create` to

--- a/braintrust/README.md
+++ b/braintrust/README.md
@@ -18,6 +18,35 @@ The `braintrust-secrets` secret must contain the following keys:
 | `GCS_ACCESS_KEY_ID` | Google HMAC Access ID string | Valid S3 API Key Id (only required if `cloud` is `google`) |
 | `GCS_SECRET_ACCESS_KEY` | Google HMAC Secret string | Valid S3 Secret string (only required if `cloud` is `google`) |
 
+## Scheduled Restarts
+
+By default, the chart creates CronJobs that perform rolling restarts of the API,
+Brainstore reader, and Brainstore writer Deployments once per hour using
+`kubectl rollout restart`. This keeps restarts graceful and leverages the
+Deployment rolling update strategy.
+
+You can customize or disable the schedules:
+
+```yaml
+scheduledRestart:
+  enabled: true
+  schedules:
+    api: "0 * * * *"
+    brainstoreReader: "10 * * * *"
+    brainstoreWriter: "20 * * * *"
+  targets:
+    brainstoreWriter: false  # Opt out of writer restarts
+  image:
+    tag: "v1.29.6"  # Optional: pin kubectl version
+```
+
+If `scheduledRestart.image.tag` is left blank, the chart defaults to the
+cluster's Kubernetes version for compatibility.
+
+If you already manage RBAC or service accounts, set
+`scheduledRestart.serviceAccount.create` and `scheduledRestart.rbac.create` to
+false and provide a `scheduledRestart.serviceAccount.name`.
+
 ## Azure Key Vault Driver Integration
 
 If you're using Azure, the Azure Key Vault CSI driver is default enabled and will automatically sync secrets from Azure Key Vault into Kubernetes. This eliminates the need to manually create and manage the `braintrust-secrets` Kubernetes secret.

--- a/braintrust/templates/scheduled-restart.yaml
+++ b/braintrust/templates/scheduled-restart.yaml
@@ -89,7 +89,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: restart
-              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default .Capabilities.KubeVersion.Version .Values.scheduledRestart.image.tag }}"
+              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default "latest" .Values.scheduledRestart.image.tag }}"
               imagePullPolicy: {{ .Values.scheduledRestart.image.pullPolicy }}
               command:
                 - kubectl
@@ -142,7 +142,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: restart
-              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default .Capabilities.KubeVersion.Version .Values.scheduledRestart.image.tag }}"
+              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default "latest" .Values.scheduledRestart.image.tag }}"
               imagePullPolicy: {{ .Values.scheduledRestart.image.pullPolicy }}
               command:
                 - kubectl
@@ -195,7 +195,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: restart
-              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default .Capabilities.KubeVersion.Version .Values.scheduledRestart.image.tag }}"
+              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default "latest" .Values.scheduledRestart.image.tag }}"
               imagePullPolicy: {{ .Values.scheduledRestart.image.pullPolicy }}
               command:
                 - kubectl

--- a/braintrust/templates/scheduled-restart.yaml
+++ b/braintrust/templates/scheduled-restart.yaml
@@ -1,0 +1,213 @@
+{{- if .Values.scheduledRestart.enabled }}
+{{- $namespace := include "braintrust.namespace" . }}
+{{- $saName := default "braintrust-restart" .Values.scheduledRestart.serviceAccount.name }}
+{{- $labels := merge .Values.global.labels .Values.scheduledRestart.labels }}
+{{- if .Values.scheduledRestart.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $namespace }}
+  {{- with .Values.scheduledRestart.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.scheduledRestart.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $namespace }}
+  {{- with $labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $namespace }}
+  {{- with $labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ $namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $saName }}
+{{- end }}
+{{- if .Values.scheduledRestart.targets.api }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.api.name }}-restart
+  namespace: {{ $namespace }}
+  {{- with $labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.scheduledRestart.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ required "scheduledRestart.schedules.api is required" .Values.scheduledRestart.schedules.api | quote }}
+  concurrencyPolicy: {{ .Values.scheduledRestart.concurrencyPolicy | default "Forbid" }}
+  startingDeadlineSeconds: {{ .Values.scheduledRestart.startingDeadlineSeconds | default 600 }}
+  successfulJobsHistoryLimit: {{ .Values.scheduledRestart.successfulJobsHistoryLimit | default 1 }}
+  failedJobsHistoryLimit: {{ .Values.scheduledRestart.failedJobsHistoryLimit | default 3 }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.scheduledRestart.backoffLimit | default 1 }}
+      {{- with .Values.scheduledRestart.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ . }}
+      {{- end }}
+      template:
+        metadata:
+          {{- with $labels }}
+          labels:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          serviceAccountName: {{ $saName }}
+          restartPolicy: Never
+          containers:
+            - name: restart
+              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default .Capabilities.KubeVersion.Version .Values.scheduledRestart.image.tag }}"
+              imagePullPolicy: {{ .Values.scheduledRestart.image.pullPolicy }}
+              command:
+                - kubectl
+              args:
+                - rollout
+                - restart
+                - deployment/{{ .Values.api.name }}
+                - --namespace
+                - {{ $namespace | quote }}
+              {{- with .Values.scheduledRestart.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+{{- end }}
+{{- if .Values.scheduledRestart.targets.brainstoreReader }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.brainstore.reader.name }}-restart
+  namespace: {{ $namespace }}
+  {{- with $labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.scheduledRestart.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ required "scheduledRestart.schedules.brainstoreReader is required" .Values.scheduledRestart.schedules.brainstoreReader | quote }}
+  concurrencyPolicy: {{ .Values.scheduledRestart.concurrencyPolicy | default "Forbid" }}
+  startingDeadlineSeconds: {{ .Values.scheduledRestart.startingDeadlineSeconds | default 600 }}
+  successfulJobsHistoryLimit: {{ .Values.scheduledRestart.successfulJobsHistoryLimit | default 1 }}
+  failedJobsHistoryLimit: {{ .Values.scheduledRestart.failedJobsHistoryLimit | default 3 }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.scheduledRestart.backoffLimit | default 1 }}
+      {{- with .Values.scheduledRestart.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ . }}
+      {{- end }}
+      template:
+        metadata:
+          {{- with $labels }}
+          labels:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          serviceAccountName: {{ $saName }}
+          restartPolicy: Never
+          containers:
+            - name: restart
+              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default .Capabilities.KubeVersion.Version .Values.scheduledRestart.image.tag }}"
+              imagePullPolicy: {{ .Values.scheduledRestart.image.pullPolicy }}
+              command:
+                - kubectl
+              args:
+                - rollout
+                - restart
+                - deployment/{{ .Values.brainstore.reader.name }}
+                - --namespace
+                - {{ $namespace | quote }}
+              {{- with .Values.scheduledRestart.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+{{- end }}
+{{- if .Values.scheduledRestart.targets.brainstoreWriter }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.brainstore.writer.name }}-restart
+  namespace: {{ $namespace }}
+  {{- with $labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.scheduledRestart.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ required "scheduledRestart.schedules.brainstoreWriter is required" .Values.scheduledRestart.schedules.brainstoreWriter | quote }}
+  concurrencyPolicy: {{ .Values.scheduledRestart.concurrencyPolicy | default "Forbid" }}
+  startingDeadlineSeconds: {{ .Values.scheduledRestart.startingDeadlineSeconds | default 600 }}
+  successfulJobsHistoryLimit: {{ .Values.scheduledRestart.successfulJobsHistoryLimit | default 1 }}
+  failedJobsHistoryLimit: {{ .Values.scheduledRestart.failedJobsHistoryLimit | default 3 }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.scheduledRestart.backoffLimit | default 1 }}
+      {{- with .Values.scheduledRestart.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ . }}
+      {{- end }}
+      template:
+        metadata:
+          {{- with $labels }}
+          labels:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          serviceAccountName: {{ $saName }}
+          restartPolicy: Never
+          containers:
+            - name: restart
+              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default .Capabilities.KubeVersion.Version .Values.scheduledRestart.image.tag }}"
+              imagePullPolicy: {{ .Values.scheduledRestart.image.pullPolicy }}
+              command:
+                - kubectl
+              args:
+                - rollout
+                - restart
+                - deployment/{{ .Values.brainstore.writer.name }}
+                - --namespace
+                - {{ $namespace | quote }}
+              {{- with .Values.scheduledRestart.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+{{- end }}
+{{- end }}

--- a/braintrust/templates/scheduled-restart.yaml
+++ b/braintrust/templates/scheduled-restart.yaml
@@ -51,7 +51,8 @@ roleRef:
   kind: Role
   name: {{ $saName }}
 {{- end }}
-{{- if .Values.scheduledRestart.targets.api }}
+{{- $hasTargets := or .Values.scheduledRestart.targets.api (or .Values.scheduledRestart.targets.brainstoreReader .Values.scheduledRestart.targets.brainstoreWriter) }}
+{{- if $hasTargets }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -67,7 +68,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  schedule: {{ required "scheduledRestart.schedules.api is required" .Values.scheduledRestart.schedules.api | quote }}
+  schedule: {{ required "scheduledRestart.schedule is required" .Values.scheduledRestart.schedule | quote }}
   concurrencyPolicy: {{ .Values.scheduledRestart.concurrencyPolicy | default "Forbid" }}
   startingDeadlineSeconds: {{ .Values.scheduledRestart.startingDeadlineSeconds | default 600 }}
   successfulJobsHistoryLimit: {{ .Values.scheduledRestart.successfulJobsHistoryLimit | default 1 }}
@@ -96,113 +97,15 @@ spec:
               args:
                 - rollout
                 - restart
+                {{- if .Values.scheduledRestart.targets.api }}
                 - deployment/{{ .Values.api.name }}
-                - --namespace
-                - {{ $namespace | quote }}
-              {{- with .Values.scheduledRestart.resources }}
-              resources:
-                {{- toYaml . | nindent 16 }}
-              {{- end }}
-{{- end }}
-{{- if .Values.scheduledRestart.targets.brainstoreReader }}
----
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: {{ .Values.brainstore.reader.name }}-restart
-  namespace: {{ $namespace }}
-  {{- with $labels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.scheduledRestart.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  schedule: {{ required "scheduledRestart.schedules.brainstoreReader is required" .Values.scheduledRestart.schedules.brainstoreReader | quote }}
-  concurrencyPolicy: {{ .Values.scheduledRestart.concurrencyPolicy | default "Forbid" }}
-  startingDeadlineSeconds: {{ .Values.scheduledRestart.startingDeadlineSeconds | default 600 }}
-  successfulJobsHistoryLimit: {{ .Values.scheduledRestart.successfulJobsHistoryLimit | default 1 }}
-  failedJobsHistoryLimit: {{ .Values.scheduledRestart.failedJobsHistoryLimit | default 3 }}
-  jobTemplate:
-    spec:
-      backoffLimit: {{ .Values.scheduledRestart.backoffLimit | default 1 }}
-      {{- with .Values.scheduledRestart.ttlSecondsAfterFinished }}
-      ttlSecondsAfterFinished: {{ . }}
-      {{- end }}
-      template:
-        metadata:
-          {{- with $labels }}
-          labels:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-        spec:
-          serviceAccountName: {{ $saName }}
-          restartPolicy: Never
-          containers:
-            - name: restart
-              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default "latest" .Values.scheduledRestart.image.tag }}"
-              imagePullPolicy: {{ .Values.scheduledRestart.image.pullPolicy }}
-              command:
-                - kubectl
-              args:
-                - rollout
-                - restart
+                {{- end }}
+                {{- if .Values.scheduledRestart.targets.brainstoreReader }}
                 - deployment/{{ .Values.brainstore.reader.name }}
-                - --namespace
-                - {{ $namespace | quote }}
-              {{- with .Values.scheduledRestart.resources }}
-              resources:
-                {{- toYaml . | nindent 16 }}
-              {{- end }}
-{{- end }}
-{{- if .Values.scheduledRestart.targets.brainstoreWriter }}
----
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: {{ .Values.brainstore.writer.name }}-restart
-  namespace: {{ $namespace }}
-  {{- with $labels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.scheduledRestart.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  schedule: {{ required "scheduledRestart.schedules.brainstoreWriter is required" .Values.scheduledRestart.schedules.brainstoreWriter | quote }}
-  concurrencyPolicy: {{ .Values.scheduledRestart.concurrencyPolicy | default "Forbid" }}
-  startingDeadlineSeconds: {{ .Values.scheduledRestart.startingDeadlineSeconds | default 600 }}
-  successfulJobsHistoryLimit: {{ .Values.scheduledRestart.successfulJobsHistoryLimit | default 1 }}
-  failedJobsHistoryLimit: {{ .Values.scheduledRestart.failedJobsHistoryLimit | default 3 }}
-  jobTemplate:
-    spec:
-      backoffLimit: {{ .Values.scheduledRestart.backoffLimit | default 1 }}
-      {{- with .Values.scheduledRestart.ttlSecondsAfterFinished }}
-      ttlSecondsAfterFinished: {{ . }}
-      {{- end }}
-      template:
-        metadata:
-          {{- with $labels }}
-          labels:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-        spec:
-          serviceAccountName: {{ $saName }}
-          restartPolicy: Never
-          containers:
-            - name: restart
-              image: "{{ .Values.scheduledRestart.image.repository }}:{{ default "latest" .Values.scheduledRestart.image.tag }}"
-              imagePullPolicy: {{ .Values.scheduledRestart.image.pullPolicy }}
-              command:
-                - kubectl
-              args:
-                - rollout
-                - restart
+                {{- end }}
+                {{- if .Values.scheduledRestart.targets.brainstoreWriter }}
                 - deployment/{{ .Values.brainstore.writer.name }}
+                {{- end }}
                 - --namespace
                 - {{ $namespace | quote }}
               {{- with .Values.scheduledRestart.resources }}

--- a/braintrust/templates/scheduled-restart.yaml
+++ b/braintrust/templates/scheduled-restart.yaml
@@ -51,8 +51,7 @@ roleRef:
   kind: Role
   name: {{ $saName }}
 {{- end }}
-{{- $hasTargets := or .Values.scheduledRestart.targets.api (or .Values.scheduledRestart.targets.brainstoreReader .Values.scheduledRestart.targets.brainstoreWriter) }}
-{{- if $hasTargets }}
+{{- if .Values.scheduledRestart.targets.api }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -97,15 +96,7 @@ spec:
               args:
                 - rollout
                 - restart
-                {{- if .Values.scheduledRestart.targets.api }}
                 - deployment/{{ .Values.api.name }}
-                {{- end }}
-                {{- if .Values.scheduledRestart.targets.brainstoreReader }}
-                - deployment/{{ .Values.brainstore.reader.name }}
-                {{- end }}
-                {{- if .Values.scheduledRestart.targets.brainstoreWriter }}
-                - deployment/{{ .Values.brainstore.writer.name }}
-                {{- end }}
                 - --namespace
                 - {{ $namespace | quote }}
               {{- with .Values.scheduledRestart.resources }}

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -68,6 +68,39 @@ objectStorage:
     # Single API bucket with paths for responses and code bundles
     apiBucket: ""
 
+scheduledRestart:
+  # Perform rolling restarts on a schedule using kubectl rollout restart.
+  enabled: true
+  targets:
+    api: true
+    brainstoreReader: true
+    brainstoreWriter: true
+  schedules:
+    api: "0 * * * *"
+    brainstoreReader: "10 * * * *"
+    brainstoreWriter: "20 * * * *"
+  image:
+    repository: "registry.k8s.io/kubectl"
+    # Defaults to the cluster Kubernetes version when left blank.
+    tag: ""
+    pullPolicy: IfNotPresent
+  serviceAccount:
+    create: true
+    name: "braintrust-restart"
+    annotations: {}
+  rbac:
+    create: true
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  backoffLimit: 1
+  # Set to enable automatic cleanup of finished jobs.
+  ttlSecondsAfterFinished: ""
+  resources: {}
+  labels: {}
+  annotations: {}
+
 api:
   name: "braintrust-api"
   labels: {}

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -80,9 +80,8 @@ scheduledRestart:
     brainstoreReader: "10 * * * *"
     brainstoreWriter: "20 * * * *"
   image:
-    repository: "registry.k8s.io/kubectl"
-    # Defaults to the cluster Kubernetes version when left blank.
-    tag: ""
+    repository: "chainguard/kubectl"
+    tag: "latest"
     pullPolicy: IfNotPresent
   serviceAccount:
     create: true

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -75,10 +75,7 @@ scheduledRestart:
     api: true
     brainstoreReader: true
     brainstoreWriter: true
-  schedules:
-    api: "0 * * * *"
-    brainstoreReader: "10 * * * *"
-    brainstoreWriter: "20 * * * *"
+  schedule: "0 * * * *"
   image:
     repository: "chainguard/kubectl"
     tag: "latest"

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -73,9 +73,7 @@ scheduledRestart:
   enabled: true
   targets:
     api: true
-    brainstoreReader: true
-    brainstoreWriter: true
-  schedule: "0 * * * *"
+  schedule: "0 0 * * *"
   image:
     repository: "chainguard/kubectl"
     tag: "latest"


### PR DESCRIPTION
Add configurable, staggered hourly rolling restarts for API and Brainstore pods to mitigate memory leaks and other issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1259d64-2fab-44ec-a23f-c83b153a2d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1259d64-2fab-44ec-a23f-c83b153a2d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

