### PR TITLE
Allow setting no limits and requests for Brainstore

### DIFF
--- a/braintrust/templates/brainstore-fastreader-deployment.yaml
+++ b/braintrust/templates/brainstore-fastreader-deployment.yaml
@@ -71,15 +71,11 @@ spec:
           ports:
             - containerPort: {{ .Values.brainstore.fastreader.service.port }}
           resources:
-            requests:
-              cpu: {{ .Values.brainstore.fastreader.resources.requests.cpu | quote }}
-              memory: {{ .Values.brainstore.fastreader.resources.requests.memory | quote }}
-              {{- if and (eq .Values.cloud "google") (eq .Values.google.mode "autopilot") .Values.brainstore.fastreader.volume.size }}
-              ephemeral-storage: {{ .Values.brainstore.fastreader.volume.size | quote }}
-              {{- end }}
-            limits:
-              cpu: {{ .Values.brainstore.fastreader.resources.limits.cpu | quote }}
-              memory: {{ .Values.brainstore.fastreader.resources.limits.memory | quote }}
+            {{- $resources := .Values.brainstore.fastreader.resources }}
+            {{- if and (eq .Values.cloud "google") (eq .Values.google.mode "autopilot") .Values.brainstore.fastreader.volume.size }}
+            {{- $resources = merge (dict "requests" (merge $resources.requests (dict "ephemeral-storage" .Values.brainstore.fastreader.volume.size))) $resources }}
+            {{- end }}
+            {{- toYaml $resources | nindent 12 }}
           {{- with .Values.brainstore.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/braintrust/templates/brainstore-reader-deployment.yaml
+++ b/braintrust/templates/brainstore-reader-deployment.yaml
@@ -71,15 +71,11 @@ spec:
           ports:
             - containerPort: {{ .Values.brainstore.reader.service.port }}
           resources:
-            requests:
-              cpu: {{ .Values.brainstore.reader.resources.requests.cpu | quote }}
-              memory: {{ .Values.brainstore.reader.resources.requests.memory | quote }}
-              {{- if and (eq .Values.cloud "google") (eq .Values.google.mode "autopilot") .Values.brainstore.reader.volume.size }}
-              ephemeral-storage: {{ .Values.brainstore.reader.volume.size | quote }}
-              {{- end }}
-            limits:
-              cpu: {{ .Values.brainstore.reader.resources.limits.cpu | quote }}
-              memory: {{ .Values.brainstore.reader.resources.limits.memory | quote }}
+            {{- $resources := .Values.brainstore.reader.resources }}
+            {{- if and (eq .Values.cloud "google") (eq .Values.google.mode "autopilot") .Values.brainstore.reader.volume.size }}
+            {{- $resources = merge (dict "requests" (merge $resources.requests (dict "ephemeral-storage" .Values.brainstore.reader.volume.size))) $resources }}
+            {{- end }}
+            {{- toYaml $resources | nindent 12 }}
           {{- with .Values.brainstore.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/braintrust/templates/brainstore-writer-deployment.yaml
+++ b/braintrust/templates/brainstore-writer-deployment.yaml
@@ -71,15 +71,11 @@ spec:
           ports:
             - containerPort: {{ .Values.brainstore.writer.service.port }}
           resources:
-            requests:
-              cpu: {{ .Values.brainstore.writer.resources.requests.cpu | quote }}
-              memory: {{ .Values.brainstore.writer.resources.requests.memory | quote }}
-              {{- if and (eq .Values.cloud "google") (eq .Values.google.mode "autopilot") .Values.brainstore.writer.volume.size }}
-              ephemeral-storage: {{ .Values.brainstore.writer.volume.size | quote }}
-              {{- end }}
-            limits:
-              cpu: {{ .Values.brainstore.writer.resources.limits.cpu | quote }}
-              memory: {{ .Values.brainstore.writer.resources.limits.memory | quote }}
+            {{- $resources := .Values.brainstore.writer.resources }}
+            {{- if and (eq .Values.cloud "google") (eq .Values.google.mode "autopilot") .Values.brainstore.writer.volume.size }}
+            {{- $resources = merge (dict "requests" (merge $resources.requests (dict "ephemeral-storage" .Values.brainstore.writer.volume.size))) $resources }}
+            {{- end }}
+            {{- toYaml $resources | nindent 12 }}
           {{- with .Values.brainstore.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
For Brainstore, pass in resources as is, other than required ones for GKE Autopilot. 