### PR TITLE
fix: add tmpVolume support to brainstore reader and writer

### DIFF
--- a/braintrust/examples/google-autopilot-cel/values.yaml
+++ b/braintrust/examples/google-autopilot-cel/values.yaml
@@ -94,6 +94,11 @@ brainstore:
         drop:
           - ALL
 
+    # Required when readOnlyRootFilesystem is true — mounts a writable emptyDir at /tmp
+    tmpVolume:
+      enabled: true
+      sizeLimit: "1Gi"
+
     volume:
       # Requests a local SSD from GKE Autopilot via ephemeral-storage resource request
       size: "1000Gi"
@@ -130,6 +135,11 @@ brainstore:
       capabilities:
         drop:
           - ALL
+
+    # Required when readOnlyRootFilesystem is true — mounts a writable emptyDir at /tmp
+    tmpVolume:
+      enabled: true
+      sizeLimit: "1Gi"
 
     volume:
       size: "1000Gi"

--- a/braintrust/templates/brainstore-reader-deployment.yaml
+++ b/braintrust/templates/brainstore-reader-deployment.yaml
@@ -138,6 +138,10 @@ spec:
           volumeMounts:
             - name: cache-volume
               mountPath: {{ .Values.brainstore.reader.cacheDir }}
+            {{- if .Values.brainstore.reader.tmpVolume.enabled }}
+            - name: tmp-volume
+              mountPath: /tmp
+            {{- end }}
             {{- if and (eq .Values.cloud "azure") .Values.azure.enableAzureKeyVaultDriver }}
             - name: secrets-store-inline
               mountPath: "/mnt/secrets-store"
@@ -163,6 +167,15 @@ spec:
             {}
             {{- end }}
           {{- end }}
+        {{- if .Values.brainstore.reader.tmpVolume.enabled }}
+        - name: tmp-volume
+          emptyDir:
+            {{- if .Values.brainstore.reader.tmpVolume.sizeLimit }}
+            sizeLimit: {{ .Values.brainstore.reader.tmpVolume.sizeLimit | quote }}
+            {{- else }}
+            {}
+            {{- end }}
+        {{- end }}
         {{- if and (eq .Values.cloud "azure") .Values.azure.enableAzureKeyVaultDriver }}
         - name: secrets-store-inline
           csi:

--- a/braintrust/templates/brainstore-writer-deployment.yaml
+++ b/braintrust/templates/brainstore-writer-deployment.yaml
@@ -138,6 +138,10 @@ spec:
           volumeMounts:
             - name: cache-volume
               mountPath: {{ .Values.brainstore.writer.cacheDir }}
+            {{- if .Values.brainstore.writer.tmpVolume.enabled }}
+            - name: tmp-volume
+              mountPath: /tmp
+            {{- end }}
             {{- if and (eq .Values.cloud "azure") .Values.azure.enableAzureKeyVaultDriver }}
             - name: secrets-store-inline
               mountPath: "/mnt/secrets-store"
@@ -163,6 +167,15 @@ spec:
             {}
             {{- end }}
           {{- end }}
+        {{- if .Values.brainstore.writer.tmpVolume.enabled }}
+        - name: tmp-volume
+          emptyDir:
+            {{- if .Values.brainstore.writer.tmpVolume.sizeLimit }}
+            sizeLimit: {{ .Values.brainstore.writer.tmpVolume.sizeLimit | quote }}
+            {{- else }}
+            {}
+            {{- end }}
+        {{- end }}
         {{- if and (eq .Values.cloud "azure") .Values.azure.enableAzureKeyVaultDriver }}
         - name: secrets-store-inline
           csi:

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -116,9 +116,9 @@ api:
   #     drop:
   #       - ALL
   # Temporary directory configuration (needed when readOnlyRootFilesystem is true)
-  # tmpVolume:
-  #   enabled: true
-  #   sizeLimit: "1Gi"
+  tmpVolume:
+    enabled: false
+    # sizeLimit: "1Gi"
   # Allow running user generated code functions (e.g. scorers/tools)
   allowCodeFunctionExecution: true
   # Brainstore backfill configuration. These defaults are fine for most cases.
@@ -235,6 +235,10 @@ brainstore:
     #   capabilities:
     #     drop:
     #       - ALL
+    # Temporary directory configuration (needed when readOnlyRootFilesystem is true)
+    tmpVolume:
+      enabled: false
+      # sizeLimit: "1Gi"
     cacheDir: "/mnt/tmp/brainstore"
     objectStoreCacheMemoryLimit: "1Gi"
     objectStoreCacheFileSize: "50Gi"
@@ -287,6 +291,10 @@ brainstore:
     #   capabilities:
     #     drop:
     #       - ALL
+    # Temporary directory configuration (needed when readOnlyRootFilesystem is true)
+    tmpVolume:
+      enabled: false
+      # sizeLimit: "1Gi"
     cacheDir: "/mnt/tmp/brainstore"
     objectStoreCacheMemoryLimit: "1Gi"
     objectStoreCacheFileSize: "50Gi"


### PR DESCRIPTION
## Summary
- Add `tmpVolume` configuration to brainstore reader and writer deployments, matching the existing API `tmpVolume` pattern
- When enabled, mounts a writable `emptyDir` at `/tmp` — required when `readOnlyRootFilesystem` is `true` for CEL policy compliance
- Fix nil pointer error in `tmpVolume` defaults: changed all three `tmpVolume` configs (API, reader, writer) from fully commented-out to actual default values (`enabled: false`), preventing template rendering failures when `tmpVolume` is not explicitly set
- Update the CEL example values to include `tmpVolume` for both brainstore reader and writer

The `require-readonly-root-filesystem` CEL policy requires all containers to use read-only root filesystems. When enabled, processes that write to `/tmp` fail unless a writable volume is mounted there. The API deployment already had this feature; this PR extends it to brainstore reader and writer.

## Changes
- `braintrust/values.yaml` — Added `tmpVolume` defaults (`enabled: false`) under `api`, `brainstore.reader`, and `brainstore.writer` (previously fully commented out, which caused nil pointer errors during `helm template`)
- `braintrust/templates/brainstore-reader-deployment.yaml` — Added conditional `tmp-volume` volumeMount and volume
- `braintrust/templates/brainstore-writer-deployment.yaml` — Added conditional `tmp-volume` volumeMount and volume
- `braintrust/examples/google-autopilot-cel/values.yaml` — Enabled `tmpVolume` for both reader and writer in the CEL example

## How to test
- `helm template` with default values renders without errors and excludes `tmp-volume`
- `helm template --set brainstore.writer.tmpVolume.enabled=true --set brainstore.writer.tmpVolume.sizeLimit=1Gi` includes the `/tmp` mount and emptyDir volume with sizeLimit
- `helm template -f examples/google-autopilot-cel/values.yaml` renders both reader and writer with `tmp-volume` correctly