### PR TITLE
Data Plane 2.0 image tags and WAL v3 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Braintrust Helm Repository
 
+For the latest guidance, always refer to the official Braintrust documentation:
+- [Self-hosting overview](https://www.braintrust.dev/docs/admin/self-hosting)
+- [Data Plane 2.0 upgrade guide](https://www.braintrust.dev/docs/admin/self-hosting/upgrade/v2)
+
 This repository contains the official Helm chart for deploying Braintrust's self-hosted data plane services to Kubernetes.
 
 ## Quick Start

--- a/braintrust/examples/google-autopilot/values.yaml
+++ b/braintrust/examples/google-autopilot/values.yaml
@@ -35,7 +35,7 @@ api:
   serviceAccount:
    name: "braintrust-api"
    googleServiceAccount: "<your Braintrust API Google service account>"
-  # this is for native GCS authentication via workload identity (defaults to false for S3-compatible access) Requires v1.1.31 or later of the dataplane to be set to true.
+  # Native GCS authentication via Workload Identity. Set to true to use GCS natively instead of S3-compatible access.
   enableGcsAuth: false
   resources:
     requests:

--- a/braintrust/examples/google-standard/values.yaml
+++ b/braintrust/examples/google-standard/values.yaml
@@ -40,7 +40,7 @@ api:
   serviceAccount:
    name: "braintrust-api"
    googleServiceAccount: "<your Braintrust API Google service account>"
-  # this is for native GCS authentication via workload identity (defaults to false for S3-compatible access) Requires v1.1.31 or later of the dataplane to be set to true.
+  # Native GCS authentication via Workload Identity. Set to true to use GCS natively instead of S3-compatible access.
   enableGcsAuth: false
   nodeSelector:
     cloud.google.com/gke-nodepool: "api"

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -218,6 +218,8 @@ tests:
   - it: should not include WAL or no-pg vars when neither is set
     values:
       - __fixtures__/base-values.yaml
+    set:
+      brainstoreWalFooterVersion: ""
     release:
       namespace: "braintrust"
     asserts:
@@ -249,6 +251,7 @@ tests:
     values:
       - __fixtures__/base-values.yaml
     set:
+      brainstoreWalFooterVersion: ""
       skipPgForBrainstoreObjects: "all"
     release:
       namespace: "braintrust"

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -81,10 +81,8 @@ objectStorage:
 skipPgForBrainstoreObjects: ""
 
 # WAL footer version controls the format of WAL entries written by Brainstore.
-# This must be enabled in a SEPARATE deploy after all nodes are running the target version.
-# Progression: "" (default) -> "v1" (on 1.1.32) -> "v3" (on 2.0, same deploy as image bump)
-# WARNING: Do not set "v3" until all nodes are running Data Plane 2.0 images.
-brainstoreWalFooterVersion: ""
+# Progression: "" (disabled) -> "v1" (on 1.1.32) -> "v3" (on 2.0)
+brainstoreWalFooterVersion: "v3"
 
 api:
   name: "braintrust-api"
@@ -99,7 +97,7 @@ api:
   replicas: 4
   image:
     repository: public.ecr.aws/braintrust/standalone-api
-    tag: v1.1.32
+    tag: v2.0.0
     pullPolicy: IfNotPresent
   service:
     # Optional name for service object. If not specified (empty), the api.name
@@ -177,7 +175,7 @@ brainstore:
   # Shared image configuration
   image:
     repository: public.ecr.aws/braintrust/brainstore
-    tag: v1.1.32
+    tag: v2.0.0
     pullPolicy: IfNotPresent
   # Locks backend configuration
   # Options: "redis" (default) or "objectStorage"


### PR DESCRIPTION
This release upgrades the Braintrust data plane to version 2.0. It includes updated container images for the API and Brainstore services, and sets the WAL footer version to v3 by default, enabling the efficient write-ahead log format that 2.0 requires.

- Bump API and Brainstore image tags to v2.0.0
- Default `brainstoreWalFooterVersion` to `"v3"` (was `""`)

For upgrade instructions, see the [Data Plane 2.0 upgrade guide](https://www.braintrust.dev/docs/admin/self-hosting/upgrade/v2).