### PR TITLE
Default no-PG mode to "all"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,11 +66,13 @@ namespace: {{ include "braintrust.namespace" . }}
 
 These constraints exist because of real incidents and confirmed engineering guidance. Do not "simplify" or "clean up" code that implements them.
 
-### Upgrade Sequencing
+### Upgrade Sequencing (for customers upgrading from pre-2.0)
 
-- **Never set `skipPgForBrainstoreObjects` on Data Plane versions before 2.0.** A known bug on 1.1.32 was hit by a customer and fixed in the 2.0 images. The correct sequence is: 1.1.32 -> WAL v1 -> 2.0 + WAL v3 -> no-PG.
+These constraints apply to customers migrating from Data Plane 1.x to 2.0. New deployments on 2.0+ ship with WAL v3 and no-PG defaults baked in.
+
+- **Never set `skipPgForBrainstoreObjects` on Data Plane versions before 2.0.** A known bug on 1.1.32 was hit by a customer and fixed in the 2.0 images. The correct upgrade sequence is: 1.1.32 -> WAL v1 -> 2.0 + WAL v3 -> no-PG.
 - **Never set `brainstoreWalFooterVersion` in the same deploy as an image version bump.** Old Brainstore nodes still rolling out cannot read the new WAL format. Exception: bumping v1 to v3 can be done in the same deploy as the 2.0 image upgrade because all 2.0 nodes understand v3.
-- **`skipPgForBrainstoreObjects` is a one-way operation.** Once enabled for an object type, it cannot be rolled back without downtime. Do not default this to any non-empty value.
+- **`skipPgForBrainstoreObjects` is a one-way operation.** Once enabled for an object type, it cannot be rolled back without downtime.
 
 ### WAL_USE_EFFICIENT_FORMAT Decoupling
 

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -220,6 +220,7 @@ tests:
       - __fixtures__/base-values.yaml
     set:
       brainstoreWalFooterVersion: ""
+      skipPgForBrainstoreObjects: ""
     release:
       namespace: "braintrust"
     asserts:
@@ -235,6 +236,7 @@ tests:
       - __fixtures__/base-values.yaml
     set:
       brainstoreWalFooterVersion: "v1"
+      skipPgForBrainstoreObjects: ""
     release:
       namespace: "braintrust"
     asserts:

--- a/braintrust/tests/brainstore-fastreader-configmap_test.yaml
+++ b/braintrust/tests/brainstore-fastreader-configmap_test.yaml
@@ -78,6 +78,8 @@ tests:
   - it: should not include no-pg vars when skipPgForBrainstoreObjects is not set
     values:
       - __fixtures__/base-values.yaml
+    set:
+      skipPgForBrainstoreObjects: ""
     release:
       namespace: "braintrust"
     asserts:

--- a/braintrust/tests/brainstore-reader-configmap_test.yaml
+++ b/braintrust/tests/brainstore-reader-configmap_test.yaml
@@ -204,6 +204,8 @@ tests:
   - it: should not include no-pg vars when skipPgForBrainstoreObjects is not set
     values:
       - __fixtures__/base-values.yaml
+    set:
+      skipPgForBrainstoreObjects: ""
     release:
       namespace: "braintrust"
     asserts:

--- a/braintrust/tests/brainstore-writer-configmap_test.yaml
+++ b/braintrust/tests/brainstore-writer-configmap_test.yaml
@@ -204,6 +204,8 @@ tests:
   - it: should not include no-pg vars when skipPgForBrainstoreObjects is not set
     values:
       - __fixtures__/base-values.yaml
+    set:
+      skipPgForBrainstoreObjects: ""
     release:
       namespace: "braintrust"
     asserts:

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -69,16 +69,12 @@ objectStorage:
     apiBucket: ""
 
 # No-PG mode: controls which object types bypass PostgreSQL and use Brainstore directly.
-# WARNING: This is a one-way operation. Once migrated off Postgres, objects cannot be
-# un-migrated without downtime.
 # Options:
-#   - "" (default): disabled, PostgreSQL used as normal
-#   - "all": skip PostgreSQL for all object types
+#   - "all" (default): skip PostgreSQL for all object types
+#   - "": disabled, PostgreSQL used as normal
 #   - "include:<type>:<uuid>,...": skip for specific objects only
-#     e.g. "include:project_logs:5ad850f0-...,project_logs:45b3aed2-..."
 #   - "exclude:<type>:<uuid>,...": skip for all objects except specific ones
-#     e.g. "exclude:project_logs:5ad850f0-..."
-skipPgForBrainstoreObjects: ""
+skipPgForBrainstoreObjects: "all"
 
 # WAL footer version controls the format of WAL entries written by Brainstore.
 # Progression: "" (disabled) -> "v1" (on 1.1.32) -> "v3" (on 2.0)


### PR DESCRIPTION
With Data Plane 2.0, Brainstore direct writes (no-PG mode) are production-ready and recommended for all deployments. This release changes the default from disabled to "all", so new deployments and upgrades automatically bypass PostgreSQL for Brainstore object writes.

- Default `skipPgForBrainstoreObjects` to `"all"` (was `""`)
- Update tests to explicitly override default where needed

For details, see the [Data Plane 2.0 upgrade guide](https://www.braintrust.dev/docs/admin/self-hosting/upgrade/v2).