### PR TITLE
[release process update] add `force_republish` option & `release/<version>` branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,8 +116,8 @@ jobs:
         run: |
           if [[ "${{ github.event.inputs.force_republish }}" == "true" ]]; then
             # Capture the SHA from the existing (broken) tag before we delete anything
-            RELEASE_SHA=$(git rev-parse $CHART_VERSION)
-            echo "ℹ️  Republishing from existing tag $CHART_VERSION @ $RELEASE_SHA"
+            START_POINT=$(git rev-parse $CHART_VERSION)
+            echo "ℹ️  Republishing from existing tag $CHART_VERSION @ $START_POINT"
 
             # Delete the existing GitHub release if present
             if gh release view $CHART_VERSION &>/dev/null; then
@@ -136,35 +136,13 @@ jobs:
               echo "⚠️  Deleting existing release branch release/$CHART_VERSION"
               git push origin --delete release/$CHART_VERSION
             fi
-
-            # Create fresh release branch from the original tag's commit
-            git checkout -b release/$CHART_VERSION $RELEASE_SHA
-
-            # Re-apply services version lock if provided
-            if [ "$SERVICES_VERSION" != "" ]; then
-              ./lock_versions $SERVICES_VERSION
-              git add .
-              if ! git diff --staged --quiet; then
-                git commit -m "Update Braintrust Services versions to $SERVICES_VERSION"
-              else
-                echo "No changes to commit for services version update"
-              fi
-            fi
-
-            # Re-apply Chart version bump in case it was missing from the broken release
-            sed -i "s/^version: .*/version: $CHART_VERSION/" $CHART_PATH/Chart.yaml
-            git add $CHART_PATH/Chart.yaml
-            if ! git diff --staged --quiet; then
-              git commit -m "Update Chart version to $CHART_VERSION"
-            else
-              echo "ℹ️  Chart.yaml already at version $CHART_VERSION"
-            fi
-
-            git push origin release/$CHART_VERSION
-
           else
+            # Normal flow publishes from main
+            START_POINT=origin/main
+
+            # Refresh origin/main — it's both the branch point (START_POINT)
+            # and the fast-forward target at the end of this step.
             git fetch origin main
-            git checkout main
 
             # Fail fast if release branch already exists — indicates a partial release
             if git ls-remote --exit-code origin refs/heads/release/$CHART_VERSION &>/dev/null; then
@@ -172,32 +150,37 @@ jobs:
               echo "Use force_republish=true to redo it from scratch"
               exit 1
             fi
+          fi
 
-            # Update services versions if provided
-            if [ "$SERVICES_VERSION" != "" ]; then
-              ./lock_versions $SERVICES_VERSION
-              git add .
-              if ! git diff --staged --quiet; then
-                git commit -m "Update Braintrust Services versions to $SERVICES_VERSION"
-              else
-                echo "No changes to commit for services version update"
-              fi
-            fi
+          # Create the release branch from the chosen starting point
+          git checkout -b release/$CHART_VERSION $START_POINT
 
-            # Update Chart version on main
-            sed -i "s/^version: .*/version: $CHART_VERSION/" $CHART_PATH/Chart.yaml
-            git add $CHART_PATH/Chart.yaml
+          # Apply services version lock if provided
+          if [ "$SERVICES_VERSION" != "" ]; then
+            ./lock_versions $SERVICES_VERSION
+            git add .
             if ! git diff --staged --quiet; then
-              git commit -m "Update Chart version to $CHART_VERSION"
+              git commit -m "Update Braintrust Services versions to $SERVICES_VERSION"
             else
-              echo "No changes to commit for Chart version update"
+              echo "No changes to commit for services version update"
             fi
+          fi
 
-            git push origin main
+          # Update Chart version
+          sed -i "s/^version: .*/version: $CHART_VERSION/" $CHART_PATH/Chart.yaml
+          git add $CHART_PATH/Chart.yaml
+          if ! git diff --staged --quiet; then
+            git commit -m "Update Chart version to $CHART_VERSION"
+          else
+            echo "ℹ️  Chart.yaml already at version $CHART_VERSION"
+          fi
 
-            # Create release branch from main's updated HEAD
-            git checkout -b release/$CHART_VERSION
-            git push origin release/$CHART_VERSION
+          git push origin release/$CHART_VERSION
+
+          # In normal mode, fast-forward main to include the version bumps.
+          # (Skipped for force_republish: the release branch diverges from main.)
+          if [[ "${{ github.event.inputs.force_republish }}" != "true" ]]; then
+            git push origin release/$CHART_VERSION:main
           fi
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,17 @@ jobs:
             # Create fresh release branch from the original tag's commit
             git checkout -b release/$CHART_VERSION $RELEASE_SHA
 
+            # Re-apply services version lock if provided
+            if [ "$SERVICES_VERSION" != "" ]; then
+              ./lock_versions $SERVICES_VERSION
+              git add .
+              if ! git diff --staged --quiet; then
+                git commit -m "Update Braintrust Services versions to $SERVICES_VERSION"
+              else
+                echo "No changes to commit for services version update"
+              fi
+            fi
+
             # Re-apply Chart version bump in case it was missing from the broken release
             sed -i "s/^version: .*/version: $CHART_VERSION/" $CHART_PATH/Chart.yaml
             git add $CHART_PATH/Chart.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,13 @@ jobs:
             git fetch origin main
             git checkout main
 
+            # Fail fast if release branch already exists — indicates a partial release
+            if git ls-remote --exit-code origin refs/heads/release/$CHART_VERSION &>/dev/null; then
+              echo "❌ Error: release/$CHART_VERSION already exists — this release may be partially complete"
+              echo "Use force_republish=true to redo it from scratch"
+              exit 1
+            fi
+
             # Update services versions if provided
             if [ "$SERVICES_VERSION" != "" ]; then
               ./lock_versions $SERVICES_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,13 +82,13 @@ jobs:
           fi
 
           if [[ "${{ github.event.inputs.force_republish }}" != "true" ]]; then
-            if git tag | grep -q "^$VERSION$"; then
+            if [[ -n "$(git tag --list "$VERSION")" ]]; then
               echo "❌ Error: Version $VERSION already exists"
               echo "Please use a different version number"
               exit 1
             fi
           else
-            if ! git tag | grep -q "^$VERSION$"; then
+            if [[ -z "$(git tag --list "$VERSION")" ]]; then
               echo "❌ Error: force_republish=true but tag $VERSION does not exist"
               echo "There is no existing release to republish"
               exit 1
@@ -119,13 +119,16 @@ jobs:
             RELEASE_SHA=$(git rev-parse $CHART_VERSION)
             echo "ℹ️  Republishing from existing tag $CHART_VERSION @ $RELEASE_SHA"
 
-            # Delete the existing GitHub release and tag
+            # Delete the existing GitHub release if present
             if gh release view $CHART_VERSION &>/dev/null; then
-              echo "⚠️  Deleting existing release and tag $CHART_VERSION"
-              gh release delete $CHART_VERSION --yes --cleanup-tag
-            else
-              echo "ℹ️  No existing GitHub release found — deleting tag directly"
-              git push origin :refs/tags/$CHART_VERSION
+              echo "⚠️  Deleting existing release $CHART_VERSION"
+              gh release delete $CHART_VERSION --yes
+            fi
+
+            # Always delete the tag explicitly
+            if git ls-remote --exit-code origin refs/tags/$CHART_VERSION &>/dev/null; then
+              echo "⚠️  Deleting existing tag $CHART_VERSION"
+              git push origin --delete refs/tags/$CHART_VERSION
             fi
 
             # Delete old release branch if it exists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         description: 'Lock onto Braintrust services version (e.g., 1.2.3)'
         required: false
         type: string
+      force_republish:
+        description: 'Re-publish an existing version'
+        required: false
+        type: boolean
+        default: false
 
 env:
   CHART_PATH: ./braintrust
@@ -38,6 +43,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.bot-token.outputs.token }}
+          fetch-tags: true
 
       - name: Configure Git
         run: |
@@ -75,10 +81,19 @@ jobs:
             exit 1
           fi
 
-          if git tag | grep -q "^$VERSION$"; then
-            echo "❌ Error: Version $VERSION already exists"
-            echo "Please use a different version number"
-            exit 1
+          if [[ "${{ github.event.inputs.force_republish }}" != "true" ]]; then
+            if git tag | grep -q "^$VERSION$"; then
+              echo "❌ Error: Version $VERSION already exists"
+              echo "Please use a different version number"
+              exit 1
+            fi
+          else
+            if ! git tag | grep -q "^$VERSION$"; then
+              echo "❌ Error: force_republish=true but tag $VERSION does not exist"
+              echo "There is no existing release to republish"
+              exit 1
+            fi
+            echo "⚠️  force_republish=true — will republish from existing tag $VERSION"
           fi
 
           # Store the cleaned version for later use
@@ -97,36 +112,79 @@ jobs:
             echo "SERVICES_VERSION=$SERVICES_VERSION" >> $GITHUB_ENV
           fi
 
-      - name: Update versions
+      - name: Prepare release branch
         run: |
-          git fetch origin main
-          git checkout main
+          if [[ "${{ github.event.inputs.force_republish }}" == "true" ]]; then
+            # Capture the SHA from the existing (broken) tag before we delete anything
+            RELEASE_SHA=$(git rev-parse $CHART_VERSION)
+            echo "ℹ️  Republishing from existing tag $CHART_VERSION @ $RELEASE_SHA"
 
-          # Update services versions if provided
-          if [ "$SERVICES_VERSION" != "" ]; then
-            ./lock_versions $SERVICES_VERSION
-            git add .
-            if ! git diff --staged --quiet; then
-              git commit -m "Update Braintrust Services versions to $SERVICES_VERSION"
+            # Delete the existing GitHub release and tag
+            if gh release view $CHART_VERSION &>/dev/null; then
+              echo "⚠️  Deleting existing release and tag $CHART_VERSION"
+              gh release delete $CHART_VERSION --yes --cleanup-tag
             else
-              echo "No changes to commit for services version update"
+              echo "ℹ️  No existing GitHub release found — deleting tag directly"
+              git push origin :refs/tags/$CHART_VERSION
             fi
-          fi
 
-          # Update Chart version
-          sed -i "s/^version: .*/version: $CHART_VERSION/" $CHART_PATH/Chart.yaml
-          git add $CHART_PATH/Chart.yaml
-          if ! git diff --staged --quiet; then
-            git commit -m "Update Chart version to $CHART_VERSION"
+            # Delete old release branch if it exists
+            if git ls-remote --exit-code origin refs/heads/release/$CHART_VERSION &>/dev/null; then
+              echo "⚠️  Deleting existing release branch release/$CHART_VERSION"
+              git push origin --delete release/$CHART_VERSION
+            fi
+
+            # Create fresh release branch from the original tag's commit
+            git checkout -b release/$CHART_VERSION $RELEASE_SHA
+
+            # Re-apply Chart version bump in case it was missing from the broken release
+            sed -i "s/^version: .*/version: $CHART_VERSION/" $CHART_PATH/Chart.yaml
+            git add $CHART_PATH/Chart.yaml
+            if ! git diff --staged --quiet; then
+              git commit -m "Update Chart version to $CHART_VERSION"
+            else
+              echo "ℹ️  Chart.yaml already at version $CHART_VERSION"
+            fi
+
+            git push origin release/$CHART_VERSION
+
           else
-            echo "No changes to commit for Chart version update"
-          fi
+            git fetch origin main
+            git checkout main
 
-          git push origin main
+            # Update services versions if provided
+            if [ "$SERVICES_VERSION" != "" ]; then
+              ./lock_versions $SERVICES_VERSION
+              git add .
+              if ! git diff --staged --quiet; then
+                git commit -m "Update Braintrust Services versions to $SERVICES_VERSION"
+              else
+                echo "No changes to commit for services version update"
+              fi
+            fi
+
+            # Update Chart version on main
+            sed -i "s/^version: .*/version: $CHART_VERSION/" $CHART_PATH/Chart.yaml
+            git add $CHART_PATH/Chart.yaml
+            if ! git diff --staged --quiet; then
+              git commit -m "Update Chart version to $CHART_VERSION"
+            else
+              echo "No changes to commit for Chart version update"
+            fi
+
+            git push origin main
+
+            # Create release branch from main's updated HEAD
+            git checkout -b release/$CHART_VERSION
+            git push origin release/$CHART_VERSION
+          fi
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
 
       - name: Create GitHub Release
         run: |
           gh release create $CHART_VERSION \
+            --target release/$CHART_VERSION \
             --draft \
             --title "$CHART_VERSION" \
             --generate-notes


### PR DESCRIPTION
## Summary

Adds a `force_republish` workflow input to recover from incomplete releases, and introduces `release/<version>` branches so every release has a clean, reproducible artifact branch with the correct `Chart.yaml`.

### Issue that inspired this PR

If the release workflow fails or is never run for a given version, there's no way to re-publish that version's chart without either bumping to a new dot release or manually running helm push locally — the tag existence check blocks re-runs.

Specific recent releases that didn't have their chart published to ECR:
* `5.1.0`
* `6.0.0`
* `6.1.0`

### Solution

Add support for republishing releases. This led to using release branches as well, because the original release process only operated on the `main` branch, and that wouldn't work for republishing older releases.  We need to rewind the repo to the state at the point of the incomplete release and publish from that.  The solution is to stop operating only on main, and instead publish from release branches.

### New: `force_republish` input

A new boolean dispatch input (default `false`) allows re-running the release workflow for a version that previously failed partway through.

- Validation requires the tag to already exist (errors if it doesn't — nothing to republish from)
- The existing GitHub release and tag are deleted, then fully recreated from scratch
- The existing `release/<version>` branch is also deleted and recreated
- Main is **not** updated — only the release branch is touched

### New: `release/<version>` branches

Every release now creates a dedicated `release/$CHART_VERSION` branch:

- **Normal flow**: version bumps (services + chart) are committed and pushed to main as before, then `release/$CHART_VERSION` is branched off main's new HEAD and pushed.
- **`force_republish` flow**: a fresh `release/$CHART_VERSION` is created from the SHA the broken tag pointed to, the `Chart.yaml` bump is re-applied (idempotent), and the branch is pushed.

`gh release create` now uses `--target release/$CHART_VERSION` in both paths, so the git tag is always created from a commit guaranteed to have the correct `Chart.yaml` version.

### Other fixes

- `fetch-tags: true` added to the checkout step so the tag existence check and `git rev-parse` in `force_republish` mode work correctly
- `GH_TOKEN` added to the "Prepare release branch" step (needed for `gh release delete` / `gh release view`)

### Testing

Tested against `erikdw/branch-based-releases-with-republish-support` via `gh workflow run`.

**Normal flow (`0.0.2-test`)**

Triggered with `version=0.0.2-test`, no `force_republish`. Verified:
- `release/0.0.2-test` branch created and pushed
- Chart.yaml bumped and pushed to main
- Draft release created via `gh release create --target release/0.0.2-test`
- Helm chart packaged successfully (`braintrust-0.0.2-test.tgz`)
- Release published with correct notes

**`force_republish` flow (`0.0.3-test`)**

Set up broken state by manually creating tag `0.0.3-test` and a draft GitHub release, then triggered with `version=0.0.3-test`, `force_republish=true`. Verified:
- Tag existence check passed, SHA captured (`8f0e5e2`)
- Existing release and tag deleted via `gh release delete --cleanup-tag`
- Fresh `release/0.0.3-test` branch created from the captured SHA
- Chart.yaml bumped on the release branch (main not touched)
- Release recreated, packaged, and published successfully

> [!NOTE]  
> Disabled the helm push to ECR for these 2 tests, since I lack permission to clean up the test artifacts there. Earlier test left some detritus that can be cleaned up: public.ecr.aws/braintrust/helm/braintrust:0.0.1-test

> [!WARNING]
> Tests as listed above weren't great because we still push to the `main` branch in the "normal" path, if we test again with this strategy we should disable any modifications to `main`.