### PR TITLE
revert Chart version to 5.0.1

### DIFF
--- a/braintrust/Chart.yaml
+++ b/braintrust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: braintrust
-version: 6.1.0
+version: 5.0.1
 description: A Helm chart to run the Braintrust services for the self-hosted data plane
 type: application
 home: https://github.com/braintrustdata/helm

--- a/braintrust/Chart.yaml
+++ b/braintrust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: braintrust
-version: 0.0.2-test
+version: 6.1.0
 description: A Helm chart to run the Braintrust services for the self-hosted data plane
 type: application
 home: https://github.com/braintrustdata/helm


### PR DESCRIPTION
Testing for new branch-based release process (PR #80) inadvertently stomped the versions in the main branch to invalid test versions.

Undoing that, and also updating the Chart version to the previous "known good" version.