### PR TITLE
[release process update] fetch git tags explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,16 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.bot-token.outputs.token }}
-          fetch-tags: true
 
       - name: Configure Git
         run: |
           git config --global user.name "Braintrust Bot"
           git config --global user.email "215900051+braintrust-bot[bot]@users.noreply.github.com"
+
+      - name: Fetch tags
+        # actions/checkout's fetch-tags option is flaky with shallow clones;
+        # fetch tags explicitly so the version-existence checks below work.
+        run: git fetch --tags --force origin
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1


### PR DESCRIPTION
## Summary
- Drops `fetch-tags: true` from the `actions/checkout` step and adds a dedicated `git fetch --tags --force origin` step.
- `fetch-tags: true` is flaky with the default shallow clone and was not reliably pulling tags — the `force_republish` validation failed with `tag 5.1.0 does not exist` even though 5.1.0 was tagged in the repo.
- `git rev-parse $CHART_VERSION` in the republish path also needs the tag local, so fetching explicitly fixes both call sites.

## Test plan
- [x] Re-dispatch the release workflow with `version=5.1.0` and `force_republish=true` and confirm the "Validate and fixup Helm version" step passes.
- [ ] Spot-check that a normal (non-republish) dispatch with a new version still validates (tag must NOT exist).
  - Idea: manually delete the release & tag for 6.1.0. Use normal process to release it.