### PR TITLE
allow code function execution disabled by default

### DIFF
--- a/braintrust/ci/values-aws.yaml
+++ b/braintrust/ci/values-aws.yaml
@@ -35,7 +35,7 @@ api:
     limits:
       cpu: "4"
       memory: "8Gi"
-  allowCodeFunctionExecution: true
+  allowCodeFunctionExecution: false
   backfillDisableHistorical: false
   backfillDisableNonhistorical: false
   allowInvalidBase64: false

--- a/braintrust/ci/values-azure.yaml
+++ b/braintrust/ci/values-azure.yaml
@@ -42,7 +42,7 @@ api:
     limits:
       cpu: "4"
       memory: "8Gi"
-  allowCodeFunctionExecution: true
+  allowCodeFunctionExecution: false
   backfillDisableHistorical: false
   backfillDisableNonhistorical: false
   allowInvalidBase64: false

--- a/braintrust/ci/values-google.yaml
+++ b/braintrust/ci/values-google.yaml
@@ -37,7 +37,7 @@ api:
     limits:
       cpu: "4"
       memory: "8Gi"
-  allowCodeFunctionExecution: true
+  allowCodeFunctionExecution: false
   backfillDisableHistorical: false
   backfillDisableNonhistorical: false
   allowInvalidBase64: false

--- a/braintrust/ci/values-minimal.yaml
+++ b/braintrust/ci/values-minimal.yaml
@@ -28,7 +28,7 @@ api:
     limits:
       cpu: "4"
       memory: "8Gi"
-  allowCodeFunctionExecution: true
+  allowCodeFunctionExecution: false
   backfillDisableHistorical: false
   backfillDisableNonhistorical: false
   allowInvalidBase64: false

--- a/braintrust/tests/__fixtures__/base-values.yaml
+++ b/braintrust/tests/__fixtures__/base-values.yaml
@@ -38,7 +38,7 @@ api:
     limits:
       cpu: "4"
       memory: "8Gi"
-  allowCodeFunctionExecution: true
+  allowCodeFunctionExecution: false
   backfillDisableHistorical: false
   backfillDisableNonhistorical: false
   allowInvalidBase64: false

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -117,7 +117,7 @@ api:
       cpu: "4"
       memory: "8Gi"
   # Allow running user generated code functions (e.g. scorers/tools)
-  allowCodeFunctionExecution: true
+  allowCodeFunctionExecution: false
   # Brainstore backfill configuration. These defaults are fine for most cases.
   backfillDisableHistorical: false
   backfillDisableNonhistorical: false


### PR DESCRIPTION
We are disabling `allowCodeFunctionExecution` by default as part of proactive security hardening.  If deployed on AWS, use the quarantine lambda functions for code execution. If using Azure or Google, please ensure your data plane is not accessible from the internet before enabling `allowCodeFunctionExecution`.