### PR TITLE
Expose backend security and org authorization settings

### DIFF
--- a/braintrust/templates/ai-gateway-configmap.yaml
+++ b/braintrust/templates/ai-gateway-configmap.yaml
@@ -22,6 +22,15 @@ data:
   BRAINTRUST_API_URL: {{ default (include "braintrust.apiInternalUrl" .) .Values.aiGateway.braintrustApiUrl | quote }}
   GATEWAY_JSON_LOGS: "true"
   GATEWAY_TELEMETRY: {{ .Values.global.controlPlaneTelemetry | quote }}
+  {{- with (.Values.api.unsafeUrlRequestMode | default "" | toString | trim) }}
+  BRAINTRUST_UNSAFE_URL_REQUEST_MODE: {{ . | quote }}
+  {{- end }}
+  {{- with (.Values.api.urlSecurityDnsServers | default "" | toString | trim) }}
+  BRAINTRUST_URL_SECURITY_DNS_SERVERS: {{ . | quote }}
+  {{- end }}
+  {{- with (.Values.api.urlSecurityAllowCidrs | default "" | toString | trim) }}
+  BRAINTRUST_URL_SECURITY_ALLOW_CIDRS: {{ . | quote }}
+  {{- end }}
   {{- if .Values.global.controlPlaneTelemetry }}
   {{- $appUrl := .Values.aiGateway.braintrustAppUrl | trimSuffix "/" }}
   OTLP_HTTP_ENDPOINT: {{ printf "%s/api/pulse/otel" $appUrl | quote }}

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -1,9 +1,3 @@
-{{- $unsafeUrlRequestMode := .Values.api.unsafeUrlRequestMode | default "" | toString | trim -}}
-{{- if not (has $unsafeUrlRequestMode (list "" "off" "warn" "reject")) -}}
-{{- fail "api.unsafeUrlRequestMode must be empty or one of: off, warn, reject." -}}
-{{- end -}}
-{{- $urlSecurityDnsServers := .Values.api.urlSecurityDnsServers | default "" | toString | trim -}}
-{{- $urlSecurityAllowCidrs := .Values.api.urlSecurityAllowCidrs | default "" | toString | trim -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -61,13 +55,13 @@ data:
   INSERT_LOGS2: "true"
   ALLOW_INVALID_BASE64: {{ .Values.api.allowInvalidBase64 | default "false" | quote }}
   NODE_MEMORY_PERCENT: {{ .Values.api.nodeMemoryPercent | default "80" | quote }}
-  {{- with $unsafeUrlRequestMode }}
+  {{- with (.Values.api.unsafeUrlRequestMode | default "" | toString | trim) }}
   BRAINTRUST_UNSAFE_URL_REQUEST_MODE: {{ . | quote }}
   {{- end }}
-  {{- with $urlSecurityDnsServers }}
+  {{- with (.Values.api.urlSecurityDnsServers | default "" | toString | trim) }}
   BRAINTRUST_URL_SECURITY_DNS_SERVERS: {{ . | quote }}
   {{- end }}
-  {{- with $urlSecurityAllowCidrs }}
+  {{- with (.Values.api.urlSecurityAllowCidrs | default "" | toString | trim) }}
   BRAINTRUST_URL_SECURITY_ALLOW_CIDRS: {{ . | quote }}
   {{- end }}
   {{- if .Values.brainstoreWalFooterVersion }}

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -1,3 +1,15 @@
+{{- $orgName := .Values.global.orgName | default "" | toString | trim -}}
+{{- $primaryOrgName := .Values.global.primaryOrgName | default "" | toString | trim -}}
+{{- $hasPrimaryOrgNameExtraEnv := false -}}
+{{- range .Values.api.extraEnvVars -}}
+{{- if eq (.name | default "" | toString) "PRIMARY_ORG_NAME" -}}
+{{- $hasPrimaryOrgNameExtraEnv = true -}}
+{{- end -}}
+{{- end -}}
+{{- if and (or (eq $orgName "") (eq $orgName "*")) (eq $primaryOrgName "") (not $hasPrimaryOrgNameExtraEnv) -}}
+{{- fail "global.primaryOrgName or api.extraEnvVars PRIMARY_ORG_NAME is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization." -}}
+{{- end -}}
+{{- $allowedOrgIds := .Values.global.allowedOrgIds | default "" | toString | trim -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -13,7 +25,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  ORG_NAME: {{ .Values.global.orgName | quote }}
+  ORG_NAME: {{ $orgName | quote }}
+  PRIMARY_ORG_NAME: {{ $primaryOrgName | quote }}
+  {{- with $allowedOrgIds }}
+  ALLOWED_ORG_IDS: {{ . | quote }}
+  {{- end }}
 
   {{- if eq .Values.cloud "azure" }}
   AZURE_STORAGE_ACCOUNT_NAME: {{ .Values.objectStorage.azure.storageAccountName | quote }}

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -1,3 +1,9 @@
+{{- $unsafeUrlRequestMode := .Values.api.unsafeUrlRequestMode | default "" | toString | trim -}}
+{{- if not (has $unsafeUrlRequestMode (list "" "off" "warn" "reject")) -}}
+{{- fail "api.unsafeUrlRequestMode must be empty or one of: off, warn, reject." -}}
+{{- end -}}
+{{- $urlSecurityDnsServers := .Values.api.urlSecurityDnsServers | default "" | toString | trim -}}
+{{- $urlSecurityAllowCidrs := .Values.api.urlSecurityAllowCidrs | default "" | toString | trim -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -55,6 +61,15 @@ data:
   INSERT_LOGS2: "true"
   ALLOW_INVALID_BASE64: {{ .Values.api.allowInvalidBase64 | default "false" | quote }}
   NODE_MEMORY_PERCENT: {{ .Values.api.nodeMemoryPercent | default "80" | quote }}
+  {{- with $unsafeUrlRequestMode }}
+  BRAINTRUST_UNSAFE_URL_REQUEST_MODE: {{ . | quote }}
+  {{- end }}
+  {{- with $urlSecurityDnsServers }}
+  BRAINTRUST_URL_SECURITY_DNS_SERVERS: {{ . | quote }}
+  {{- end }}
+  {{- with $urlSecurityAllowCidrs }}
+  BRAINTRUST_URL_SECURITY_ALLOW_CIDRS: {{ . | quote }}
+  {{- end }}
   {{- if .Values.brainstoreWalFooterVersion }}
   BRAINSTORE_WAL_FOOTER_VERSION: {{ .Values.brainstoreWalFooterVersion | quote }}
   {{- end }}

--- a/braintrust/tests/ai-gateway-configmap_test.yaml
+++ b/braintrust/tests/ai-gateway-configmap_test.yaml
@@ -41,9 +41,36 @@ tests:
       - equal:
           path: data.GATEWAY_TELEMETRY
           value: "status,metrics"
+      - isNull:
+          path: data.BRAINTRUST_UNSAFE_URL_REQUEST_MODE
+      - isNull:
+          path: data.BRAINTRUST_URL_SECURITY_DNS_SERVERS
+      - isNull:
+          path: data.BRAINTRUST_URL_SECURITY_ALLOW_CIDRS
       - equal:
           path: data.OTLP_HTTP_ENDPOINT
           value: "https://www.braintrust.dev/api/pulse/otel"
+
+  - it: should include URL security env vars when configured
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      api.unsafeUrlRequestMode: " proxy "
+      api.urlSecurityDnsServers: " 1.1.1.1,8.8.8.8 "
+      api.urlSecurityAllowCidrs: " 10.0.0.0/8,192.168.0.0/16 "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.BRAINTRUST_UNSAFE_URL_REQUEST_MODE
+          value: "proxy"
+      - equal:
+          path: data.BRAINTRUST_URL_SECURITY_DNS_SERVERS
+          value: "1.1.1.1,8.8.8.8"
+      - equal:
+          path: data.BRAINTRUST_URL_SECURITY_ALLOW_CIDRS
+          value: "10.0.0.0/8,192.168.0.0/16"
 
   - it: should set GATEWAY_REGION when region is provided
     values:

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -83,13 +83,13 @@ tests:
     values:
       - __fixtures__/base-values.yaml
     set:
-      global.allowedOrgIds: " org_123,org_456 "
+      global.allowedOrgIds: " 00000000-0000-4000-8000-000000000001,00000000-0000-4000-8000-000000000002 "
     release:
       namespace: "braintrust"
     asserts:
       - equal:
           path: data.ALLOWED_ORG_IDS
-          value: "org_123,org_456"
+          value: "00000000-0000-4000-8000-000000000001,00000000-0000-4000-8000-000000000002"
 
   - it: should include primary org name when configured
     values:

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -23,6 +23,50 @@ tests:
           path: data.BRAINSTORE_DEFAULT
           value: "force"
 
+  - it: should omit URL security env vars when unset
+    values:
+      - __fixtures__/base-values.yaml
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isNull:
+          path: data.BRAINTRUST_UNSAFE_URL_REQUEST_MODE
+      - isNull:
+          path: data.BRAINTRUST_URL_SECURITY_DNS_SERVERS
+      - isNull:
+          path: data.BRAINTRUST_URL_SECURITY_ALLOW_CIDRS
+
+  - it: should include URL security env vars when configured
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      api.unsafeUrlRequestMode: " reject "
+      api.urlSecurityDnsServers: " 1.1.1.1,8.8.8.8 "
+      api.urlSecurityAllowCidrs: " 10.0.0.0/8,192.168.0.0/16 "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.BRAINTRUST_UNSAFE_URL_REQUEST_MODE
+          value: "reject"
+      - equal:
+          path: data.BRAINTRUST_URL_SECURITY_DNS_SERVERS
+          value: "1.1.1.1,8.8.8.8"
+      - equal:
+          path: data.BRAINTRUST_URL_SECURITY_ALLOW_CIDRS
+          value: "10.0.0.0/8,192.168.0.0/16"
+
+  - it: should reject invalid URL request mode
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      api.unsafeUrlRequestMode: "block"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - failedTemplate:
+          errorMessage: "api.unsafeUrlRequestMode must be empty or one of: off, warn, reject."
+
   - it: should use correct namespace from helper when createNamespace is false
     values:
       - __fixtures__/base-values.yaml

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -56,17 +56,6 @@ tests:
           path: data.BRAINTRUST_URL_SECURITY_ALLOW_CIDRS
           value: "10.0.0.0/8,192.168.0.0/16"
 
-  - it: should reject invalid URL request mode
-    values:
-      - __fixtures__/base-values.yaml
-    set:
-      api.unsafeUrlRequestMode: "block"
-    release:
-      namespace: "braintrust"
-    asserts:
-      - failedTemplate:
-          errorMessage: "api.unsafeUrlRequestMode must be empty or one of: off, warn, reject."
-
   - it: should use correct namespace from helper when createNamespace is false
     values:
       - __fixtures__/base-values.yaml

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -17,6 +17,9 @@ tests:
           path: data.ORG_NAME
           value: "test-org"
       - equal:
+          path: data.PRIMARY_ORG_NAME
+          value: ""
+      - equal:
           path: data.BRAINSTORE_ENABLED
           value: "true"
       - equal:
@@ -55,6 +58,109 @@ tests:
       - equal:
           path: data.BRAINTRUST_URL_SECURITY_ALLOW_CIDRS
           value: "10.0.0.0/8,192.168.0.0/16"
+
+  - it: should omit allowed org IDs when unset
+    values:
+      - __fixtures__/base-values.yaml
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isNull:
+          path: data.ALLOWED_ORG_IDS
+
+  - it: should omit allowed org IDs when blank
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.allowedOrgIds: "   "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isNull:
+          path: data.ALLOWED_ORG_IDS
+
+  - it: should include allowed org IDs when configured
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.allowedOrgIds: " org_123,org_456 "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.ALLOWED_ORG_IDS
+          value: "org_123,org_456"
+
+  - it: should include primary org name when configured
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.primaryOrgName: " primary-org "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.PRIMARY_ORG_NAME
+          value: "primary-org"
+
+  - it: should allow wildcard org name when primary org name is configured
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.orgName: "*"
+      global.primaryOrgName: "primary-org"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.ORG_NAME
+          value: "*"
+      - equal:
+          path: data.PRIMARY_ORG_NAME
+          value: "primary-org"
+
+  - it: should allow wildcard org name when primary org name is provided via extra env vars
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.orgName: "*"
+      global.primaryOrgName: ""
+      api.extraEnvVars:
+        - name: PRIMARY_ORG_NAME
+          value: "primary-org"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.ORG_NAME
+          value: "*"
+      - equal:
+          path: data.PRIMARY_ORG_NAME
+          value: ""
+
+  - it: should reject empty org name without primary org name
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.orgName: ""
+      global.primaryOrgName: ""
+    release:
+      namespace: "braintrust"
+    asserts:
+      - failedTemplate:
+          errorMessage: "global.primaryOrgName or api.extraEnvVars PRIMARY_ORG_NAME is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization."
+
+  - it: should reject wildcard org name without primary org name
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.orgName: "*"
+      global.primaryOrgName: "   "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - failedTemplate:
+          errorMessage: "global.primaryOrgName or api.extraEnvVars PRIMARY_ORG_NAME is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization."
 
   - it: should use correct namespace from helper when createNamespace is false
     values:

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -126,6 +126,20 @@ api:
   backfillDisableNonhistorical: false
   allowInvalidBase64: false  # By default, we will error on invalid base64 strings. Setting this to true will allow invalid base64 strings to be processed.
   nodeMemoryPercent: "80"
+  # Controls how Braintrust backends handle outbound requests to user-supplied URLs
+  # that fail URL-security checks, such as URLs resolving to private or reserved IP
+  # ranges. Use "off" to allow, "warn" to allow with warnings, or "reject" to block.
+  # Leave empty to use the application default of "warn".
+  unsafeUrlRequestMode: ""
+  # Comma-separated DNS resolver IP addresses Braintrust backends should query when
+  # checking user-supplied URLs. Set this to force URL-security validation through
+  # trusted resolvers, such as VNet or corporate DNS, before falling back to the host
+  # resolver. Leave empty to use the application default resolver behavior.
+  urlSecurityDnsServers: ""
+  # Optional comma-separated CIDR ranges that Braintrust backend URL-security
+  # validation may allow even if private or reserved. Hard-blocked metadata,
+  # link-local, multicast, unspecified, and future-use ranges remain blocked.
+  urlSecurityAllowCidrs: ""
   extraEnvVars:
     # Example:
     # - name: MY_ENV_VAR

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -4,8 +4,9 @@ global:
   # Required when orgName is empty or "*" unless PRIMARY_ORG_NAME is supplied
   # via api.extraEnvVars. Used to authorize self-hosted service-token management.
   primaryOrgName: ""
-  # Optional comma-separated org ID allowlist. If orgName is a specific name,
-  # that org is included in the allowlist.
+  # Optional comma-separated Braintrust Org ID allowlist (IDs, not org names).
+  # Do not include spaces. If orgName is a specific name, that org is included
+  # in the allowlist; include its Braintrust Org ID here for forward compatibility.
   allowedOrgIds: ""
   # When createNamespace is true, the namespace will be created and resources will be in global.namespace
   # When createNamespace is false, resources will use .Release.Namespace (the namespace specified during helm install/upgrade)
@@ -134,8 +135,9 @@ api:
   nodeMemoryPercent: "80"
   # Controls how Braintrust backends handle outbound requests to user-supplied URLs
   # that fail URL-security checks, such as URLs resolving to private or reserved IP
-  # ranges. Use "off" to allow, "warn" to allow with warnings, or "reject" to block.
-  # Leave empty to use the application default of "warn".
+  # ranges. Applies to the API and AI Gateway when configured. Use "off" to allow,
+  # "proxy" to proxy, "warn" to allow with warnings, or "reject" to block. Leave
+  # empty to use the application default of "warn".
   unsafeUrlRequestMode: ""
   # Comma-separated DNS resolver IP addresses Braintrust backends should query when
   # checking user-supplied URLs. Set this to force URL-security validation through

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -1,6 +1,12 @@
 # Global configs
 global:
   orgName: "<your org name on Braintrust>"
+  # Required when orgName is empty or "*" unless PRIMARY_ORG_NAME is supplied
+  # via api.extraEnvVars. Used to authorize self-hosted service-token management.
+  primaryOrgName: ""
+  # Optional comma-separated org ID allowlist. If orgName is a specific name,
+  # that org is included in the allowlist.
+  allowedOrgIds: ""
   # When createNamespace is true, the namespace will be created and resources will be in global.namespace
   # When createNamespace is false, resources will use .Release.Namespace (the namespace specified during helm install/upgrade)
   createNamespace: false


### PR DESCRIPTION
### Context

Self-hosted Braintrust deployments need first-class Helm values for two backend security controls that previously required `extraEnvVars`: URL-security behavior for outbound requests to user-supplied URLs, and organization authorization settings for hybrid/self-hosted data planes. This mirrors the Terraform data-plane inputs for API and AI Gateway runtime security configuration.

### Description

- Adds optional URL-security values for unsafe request mode, DNS resolvers, and allowed CIDRs, rendering the corresponding `BRAINTRUST_*` ConfigMap env vars for the API and AI Gateway only when trimmed values are non-empty.
- Documents the Terraform-supported unsafe request modes, including `proxy`, while preserving application defaults when values are unset.
- Adds global organization authorization values for `ALLOWED_ORG_IDS` and `PRIMARY_ORG_NAME`, preserving current behavior when unset or blank.
- Requires a primary org when `global.orgName` is empty or `"*"`, while preserving existing deployments that already provide `PRIMARY_ORG_NAME` through `api.extraEnvVars`.
- Covers omitted, blank, configured, wildcard, extra-env override, and validation cases in the ConfigMap template tests.
