### PR TITLE
Expose allowed org ID authorization settings

### DIFF
--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -1,7 +1,13 @@
 {{- $orgName := .Values.global.orgName | default "" | toString | trim -}}
 {{- $primaryOrgName := .Values.global.primaryOrgName | default "" | toString | trim -}}
-{{- if and (or (eq $orgName "") (eq $orgName "*")) (eq $primaryOrgName "") -}}
-{{- fail "global.primaryOrgName is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization." -}}
+{{- $hasPrimaryOrgNameExtraEnv := false -}}
+{{- range .Values.api.extraEnvVars -}}
+{{- if eq (.name | default "" | toString) "PRIMARY_ORG_NAME" -}}
+{{- $hasPrimaryOrgNameExtraEnv = true -}}
+{{- end -}}
+{{- end -}}
+{{- if and (or (eq $orgName "") (eq $orgName "*")) (eq $primaryOrgName "") (not $hasPrimaryOrgNameExtraEnv) -}}
+{{- fail "global.primaryOrgName or api.extraEnvVars PRIMARY_ORG_NAME is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization." -}}
 {{- end -}}
 {{- $allowedOrgIds := .Values.global.allowedOrgIds | default "" | toString | trim -}}
 ---

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -1,3 +1,9 @@
+{{- $orgName := .Values.global.orgName | default "" | toString | trim -}}
+{{- $primaryOrgName := .Values.global.primaryOrgName | default "" | toString | trim -}}
+{{- if and (or (eq $orgName "") (eq $orgName "*")) (eq $primaryOrgName "") -}}
+{{- fail "global.primaryOrgName is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization." -}}
+{{- end -}}
+{{- $allowedOrgIds := .Values.global.allowedOrgIds | default "" | toString | trim -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -13,7 +19,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  ORG_NAME: {{ .Values.global.orgName | quote }}
+  ORG_NAME: {{ $orgName | quote }}
+  PRIMARY_ORG_NAME: {{ $primaryOrgName | quote }}
+  {{- with $allowedOrgIds }}
+  ALLOWED_ORG_IDS: {{ . | quote }}
+  {{- end }}
 
   {{- if eq .Values.cloud "azure" }}
   AZURE_STORAGE_ACCOUNT_NAME: {{ .Values.objectStorage.azure.storageAccountName | quote }}

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -17,6 +17,9 @@ tests:
           path: data.ORG_NAME
           value: "test-org"
       - equal:
+          path: data.PRIMARY_ORG_NAME
+          value: ""
+      - equal:
           path: data.BRAINSTORE_ENABLED
           value: "true"
       - equal:
@@ -55,6 +58,90 @@ tests:
       - equal:
           path: data.BRAINTRUST_URL_SECURITY_ALLOW_CIDRS
           value: "10.0.0.0/8,192.168.0.0/16"
+
+  - it: should omit allowed org IDs when unset
+    values:
+      - __fixtures__/base-values.yaml
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isNull:
+          path: data.ALLOWED_ORG_IDS
+
+  - it: should omit allowed org IDs when blank
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.allowedOrgIds: "   "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isNull:
+          path: data.ALLOWED_ORG_IDS
+
+  - it: should include allowed org IDs when configured
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.allowedOrgIds: " org_123,org_456 "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.ALLOWED_ORG_IDS
+          value: "org_123,org_456"
+
+  - it: should include primary org name when configured
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.primaryOrgName: " primary-org "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.PRIMARY_ORG_NAME
+          value: "primary-org"
+
+  - it: should allow wildcard org name when primary org name is configured
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.orgName: "*"
+      global.primaryOrgName: "primary-org"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.ORG_NAME
+          value: "*"
+      - equal:
+          path: data.PRIMARY_ORG_NAME
+          value: "primary-org"
+
+  - it: should reject empty org name without primary org name
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.orgName: ""
+      global.primaryOrgName: ""
+    release:
+      namespace: "braintrust"
+    asserts:
+      - failedTemplate:
+          errorMessage: "global.primaryOrgName is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization."
+
+  - it: should reject wildcard org name without primary org name
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.orgName: "*"
+      global.primaryOrgName: "   "
+    release:
+      namespace: "braintrust"
+    asserts:
+      - failedTemplate:
+          errorMessage: "global.primaryOrgName is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization."
 
   - it: should use correct namespace from helper when createNamespace is false
     values:

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -119,6 +119,25 @@ tests:
           path: data.PRIMARY_ORG_NAME
           value: "primary-org"
 
+  - it: should allow wildcard org name when primary org name is provided via extra env vars
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      global.orgName: "*"
+      global.primaryOrgName: ""
+      api.extraEnvVars:
+        - name: PRIMARY_ORG_NAME
+          value: "primary-org"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.ORG_NAME
+          value: "*"
+      - equal:
+          path: data.PRIMARY_ORG_NAME
+          value: ""
+
   - it: should reject empty org name without primary org name
     values:
       - __fixtures__/base-values.yaml
@@ -129,7 +148,7 @@ tests:
       namespace: "braintrust"
     asserts:
       - failedTemplate:
-          errorMessage: "global.primaryOrgName is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization."
+          errorMessage: "global.primaryOrgName or api.extraEnvVars PRIMARY_ORG_NAME is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization."
 
   - it: should reject wildcard org name without primary org name
     values:
@@ -141,7 +160,7 @@ tests:
       namespace: "braintrust"
     asserts:
       - failedTemplate:
-          errorMessage: "global.primaryOrgName is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization."
+          errorMessage: "global.primaryOrgName or api.extraEnvVars PRIMARY_ORG_NAME is required when global.orgName is empty or \"*\"; self-hosted service-token management needs a primary organization."
 
   - it: should use correct namespace from helper when createNamespace is false
     values:

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -1,8 +1,8 @@
 # Global configs
 global:
   orgName: "<your org name on Braintrust>"
-  # Required when orgName is empty or "*". Used to authorize self-hosted
-  # service-token management.
+  # Required when orgName is empty or "*" unless PRIMARY_ORG_NAME is supplied
+  # via api.extraEnvVars. Used to authorize self-hosted service-token management.
   primaryOrgName: ""
   # Optional comma-separated org ID allowlist. If orgName is a specific name,
   # that org is included in the allowlist.

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -1,6 +1,12 @@
 # Global configs
 global:
   orgName: "<your org name on Braintrust>"
+  # Required when orgName is empty or "*". Used to authorize self-hosted
+  # service-token management.
+  primaryOrgName: ""
+  # Optional comma-separated org ID allowlist. If orgName is a specific name,
+  # that org is included in the allowlist.
+  allowedOrgIds: ""
   # When createNamespace is true, the namespace will be created and resources will be in global.namespace
   # When createNamespace is false, resources will use .Release.Namespace (the namespace specified during helm install/upgrade)
   createNamespace: false


### PR DESCRIPTION
### Context

Hybrid/self-hosted data planes need a first-class Helm value for authorizing access by stable Braintrust organization IDs, matching the Terraform data-plane support for `ALLOWED_ORG_IDS`. Deployments that use wildcard or empty org-name access also need an explicit primary org for self-hosted service-token management.

### Description

- Adds `global.allowedOrgIds` and renders `ALLOWED_ORG_IDS` into the API ConfigMap only when the trimmed value is non-empty.
- Adds `global.primaryOrgName` and renders `PRIMARY_ORG_NAME` alongside the existing trimmed `ORG_NAME`.
- Fails template rendering when `global.orgName` is empty or `"*"` and `global.primaryOrgName` is empty, matching the Terraform module validation boundary.
- Covers omitted, blank, configured, wildcard-with-primary, and invalid empty/wildcard cases in API ConfigMap tests.
