### PR TITLE
[beta] Add an optional deployment for AI Gateway

### DIFF
--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install helm-unittest
         run: |
-          helm plugin install https://github.com/quintush/helm-unittest --verify=false
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 
       - name: Run unit tests
         run: |

--- a/braintrust/templates/_helpers.tpl
+++ b/braintrust/templates/_helpers.tpl
@@ -33,6 +33,13 @@ http://{{ .Values.api.service.name | default .Values.api.name }}.{{ include "bra
 {{- end -}}
 
 {{/*
+Internal cluster URL for the AI Gateway service.
+*/}}
+{{- define "braintrust.aiGatewayInternalUrl" -}}
+http://{{ .Values.aiGateway.service.name | default .Values.aiGateway.name }}.{{ include "braintrust.namespace" . }}:{{ .Values.aiGateway.service.port }}
+{{- end -}}
+
+{{/*
 Render Brainstore container resources with provider-specific ephemeral storage.
 
 Google Autopilot keeps the legacy behavior of defaulting the ephemeral-storage

--- a/braintrust/templates/_helpers.tpl
+++ b/braintrust/templates/_helpers.tpl
@@ -26,6 +26,13 @@ Static fast reader query sources used by API.
 {{- end -}}
 
 {{/*
+Internal cluster URL for the API service.
+*/}}
+{{- define "braintrust.apiInternalUrl" -}}
+http://{{ .Values.api.service.name | default .Values.api.name }}.{{ include "braintrust.namespace" . }}:{{ .Values.api.service.port }}
+{{- end -}}
+
+{{/*
 Render Brainstore container resources with provider-specific ephemeral storage.
 
 Google Autopilot keeps the legacy behavior of defaulting the ephemeral-storage

--- a/braintrust/templates/ai-gateway-configmap.yaml
+++ b/braintrust/templates/ai-gateway-configmap.yaml
@@ -22,6 +22,8 @@ data:
   BRAINTRUST_API_URL: {{ default (include "braintrust.apiInternalUrl" .) .Values.aiGateway.braintrustApiUrl | quote }}
   GATEWAY_JSON_LOGS: "true"
   GATEWAY_TELEMETRY: {{ .Values.global.controlPlaneTelemetry | quote }}
+  {{- if .Values.global.controlPlaneTelemetry }}
   {{- $appUrl := .Values.aiGateway.braintrustAppUrl | trimSuffix "/" }}
-  OTLP_HTTP_ENDPOINT: {{ default (printf "%s/api/pulse/otel" $appUrl) .Values.aiGateway.otlpHttpEndpoint | quote }}
+  OTLP_HTTP_ENDPOINT: {{ printf "%s/api/pulse/otel" $appUrl | quote }}
+  {{- end }}
 {{- end }}

--- a/braintrust/templates/ai-gateway-configmap.yaml
+++ b/braintrust/templates/ai-gateway-configmap.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.aiGateway.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.aiGateway.name }}
+  namespace: {{ include "braintrust.namespace" . }}
+  {{- with (merge (deepCopy .Values.aiGateway.labels) .Values.global.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.aiGateway.annotations.configmap }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  GATEWAY_ENV: "production"
+  {{- if .Values.aiGateway.region }}
+  GATEWAY_REGION: {{ .Values.aiGateway.region | quote }}
+  {{- end }}
+  BRAINTRUST_APP_URL: {{ .Values.aiGateway.braintrustAppUrl | quote }}
+  BRAINTRUST_API_URL: {{ default (include "braintrust.apiInternalUrl" .) .Values.aiGateway.braintrustApiUrl | quote }}
+  GATEWAY_JSON_LOGS: "true"
+  GATEWAY_TELEMETRY: {{ .Values.global.controlPlaneTelemetry | quote }}
+  OTLP_HTTP_ENDPOINT: {{ .Values.aiGateway.otlpHttpEndpoint | quote }}
+{{- end }}

--- a/braintrust/templates/ai-gateway-configmap.yaml
+++ b/braintrust/templates/ai-gateway-configmap.yaml
@@ -22,5 +22,6 @@ data:
   BRAINTRUST_API_URL: {{ default (include "braintrust.apiInternalUrl" .) .Values.aiGateway.braintrustApiUrl | quote }}
   GATEWAY_JSON_LOGS: "true"
   GATEWAY_TELEMETRY: {{ .Values.global.controlPlaneTelemetry | quote }}
-  OTLP_HTTP_ENDPOINT: {{ .Values.aiGateway.otlpHttpEndpoint | quote }}
+  {{- $appUrl := .Values.aiGateway.braintrustAppUrl | trimSuffix "/" }}
+  OTLP_HTTP_ENDPOINT: {{ default (printf "%s/api/pulse/otel" $appUrl) .Values.aiGateway.otlpHttpEndpoint | quote }}
 {{- end }}

--- a/braintrust/templates/ai-gateway-deployment.yaml
+++ b/braintrust/templates/ai-gateway-deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.aiGateway.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.aiGateway.name }}
+  namespace: {{ include "braintrust.namespace" . }}
+  {{- with (merge (deepCopy .Values.aiGateway.labels) .Values.global.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.aiGateway.annotations.deployment }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.aiGateway.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: {{ .Values.aiGateway.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.aiGateway.name }}
+        {{- with (merge (deepCopy .Values.aiGateway.podLabels) .Values.aiGateway.labels .Values.global.labels) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ai-gateway-configmap.yaml") . | sha256sum }}
+        {{- with .Values.aiGateway.annotations.pod }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.aiGateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.aiGateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.aiGateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: ai-gateway
+          image: "{{ .Values.aiGateway.image.repository }}:{{ .Values.aiGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.aiGateway.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.aiGateway.service.port }}
+          resources:
+            {{- toYaml .Values.aiGateway.resources | nindent 12 }}
+          {{- with .Values.aiGateway.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.aiGateway.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.aiGateway.name }}
+          env:
+            - name: COMPLETIONS_CACHE_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: braintrust-secrets
+                  key: REDIS_URL
+            - name: AUTH_CACHE_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: braintrust-secrets
+                  key: REDIS_URL
+            - name: BRAINSTORE_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: braintrust-secrets
+                  key: BRAINSTORE_LICENSE_KEY
+            {{- if .Values.aiGateway.extraEnvVars }}
+            {{- toYaml .Values.aiGateway.extraEnvVars | nindent 12 }}
+            {{- end }}
+      {{- with .Values.aiGateway.extraContainers }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- with .Values.aiGateway.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
+        []
+        {{- end }}
+{{- end }}

--- a/braintrust/templates/ai-gateway-service.yaml
+++ b/braintrust/templates/ai-gateway-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.aiGateway.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.aiGateway.service.name | default .Values.aiGateway.name }}
+  namespace: {{ include "braintrust.namespace" . }}
+  {{- with (merge (deepCopy .Values.aiGateway.labels) .Values.global.labels) }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.aiGateway.annotations.service }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    app: {{ .Values.aiGateway.name }}
+  ports:
+    - name: {{ .Values.aiGateway.service.portName }}
+      protocol: TCP
+      port: {{ .Values.aiGateway.service.port }}
+      targetPort: {{ .Values.aiGateway.service.port }}
+  type: {{ .Values.aiGateway.service.type }}
+{{- end }}

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -64,6 +64,6 @@ data:
   {{- if or .Values.brainstoreWalFooterVersion .Values.skipPgForBrainstoreObjects }}
   BRAINSTORE_WAL_USE_EFFICIENT_FORMAT: "true"
   {{- end }}
-  {{- if .Values.aiGateway.enabled }}
+  {{- if .Values.aiGateway.useGateway }}
   GATEWAY_URL: {{ include "braintrust.aiGatewayInternalUrl" . | quote }}
   {{- end }}

--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -64,3 +64,6 @@ data:
   {{- if or .Values.brainstoreWalFooterVersion .Values.skipPgForBrainstoreObjects }}
   BRAINSTORE_WAL_USE_EFFICIENT_FORMAT: "true"
   {{- end }}
+  {{- if .Values.aiGateway.enabled }}
+  GATEWAY_URL: {{ include "braintrust.aiGatewayInternalUrl" . | quote }}
+  {{- end }}

--- a/braintrust/tests/ai-gateway-configmap_test.yaml
+++ b/braintrust/tests/ai-gateway-configmap_test.yaml
@@ -86,6 +86,18 @@ tests:
           path: data.BRAINTRUST_API_URL
           value: "https://api.example.com"
 
+  - it: should omit OTLP_HTTP_ENDPOINT when control plane telemetry is disabled
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      global.controlPlaneTelemetry: ""
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isNull:
+          path: data.OTLP_HTTP_ENDPOINT
+
   - it: should derive OTLP_HTTP_ENDPOINT from braintrustAppUrl
     values:
       - __fixtures__/base-values.yaml
@@ -111,17 +123,3 @@ tests:
       - equal:
           path: data.OTLP_HTTP_ENDPOINT
           value: "https://control.example.com/api/pulse/otel"
-
-  - it: should use custom otlpHttpEndpoint when provided
-    values:
-      - __fixtures__/base-values.yaml
-    set:
-      aiGateway.enabled: true
-      aiGateway.braintrustAppUrl: "https://control.example.com"
-      aiGateway.otlpHttpEndpoint: "https://otel.example.com/v1"
-    release:
-      namespace: "braintrust"
-    asserts:
-      - equal:
-          path: data.OTLP_HTTP_ENDPOINT
-          value: "https://otel.example.com/v1"

--- a/braintrust/tests/ai-gateway-configmap_test.yaml
+++ b/braintrust/tests/ai-gateway-configmap_test.yaml
@@ -85,3 +85,43 @@ tests:
       - equal:
           path: data.BRAINTRUST_API_URL
           value: "https://api.example.com"
+
+  - it: should derive OTLP_HTTP_ENDPOINT from braintrustAppUrl
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.braintrustAppUrl: "https://control.example.com"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.OTLP_HTTP_ENDPOINT
+          value: "https://control.example.com/api/pulse/otel"
+
+  - it: should derive OTLP_HTTP_ENDPOINT from braintrustAppUrl with trailing slash
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.braintrustAppUrl: "https://control.example.com/"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.OTLP_HTTP_ENDPOINT
+          value: "https://control.example.com/api/pulse/otel"
+
+  - it: should use custom otlpHttpEndpoint when provided
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.braintrustAppUrl: "https://control.example.com"
+      aiGateway.otlpHttpEndpoint: "https://otel.example.com/v1"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.OTLP_HTTP_ENDPOINT
+          value: "https://otel.example.com/v1"

--- a/braintrust/tests/ai-gateway-configmap_test.yaml
+++ b/braintrust/tests/ai-gateway-configmap_test.yaml
@@ -1,0 +1,87 @@
+suite: test AI gateway configmap template
+templates:
+  - ai-gateway-configmap.yaml
+tests:
+  - it: should not render when ai-gateway is disabled
+    values:
+      - __fixtures__/base-values.yaml
+    release:
+      namespace: "braintrust"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ai-gateway configmap when enabled
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: braintrust-ai-gateway
+      - equal:
+          path: data.GATEWAY_ENV
+          value: "production"
+      - isNull:
+          path: data.GATEWAY_REGION
+      - equal:
+          path: data.BRAINTRUST_APP_URL
+          value: "https://www.braintrust.dev"
+      - equal:
+          path: data.BRAINTRUST_API_URL
+          value: "http://braintrust-api.braintrust:8000"
+      - equal:
+          path: data.GATEWAY_JSON_LOGS
+          value: "true"
+      - equal:
+          path: data.GATEWAY_TELEMETRY
+          value: "status,metrics"
+      - equal:
+          path: data.OTLP_HTTP_ENDPOINT
+          value: "https://www.braintrust.dev/api/pulse/otel"
+
+  - it: should set GATEWAY_REGION when region is provided
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.region: "us-east-1"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.GATEWAY_REGION
+          value: "us-east-1"
+
+  - it: should use global controlPlaneTelemetry for GATEWAY_TELEMETRY
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.region: "us-east-1"
+      global.controlPlaneTelemetry: "status,metrics,usage,logs"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.GATEWAY_TELEMETRY
+          value: "status,metrics,usage,logs"
+
+  - it: should use custom braintrustApiUrl when provided
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.region: "us-east-1"
+      aiGateway.braintrustApiUrl: "https://api.example.com"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.BRAINTRUST_API_URL
+          value: "https://api.example.com"

--- a/braintrust/tests/ai-gateway-deployment_test.yaml
+++ b/braintrust/tests/ai-gateway-deployment_test.yaml
@@ -1,0 +1,117 @@
+suite: test AI gateway deployment template
+templates:
+  - ai-gateway-deployment.yaml
+  - ai-gateway-configmap.yaml
+tests:
+  - it: should not render when ai-gateway is disabled
+    template: ai-gateway-deployment.yaml
+    values:
+      - __fixtures__/base-values.yaml
+    release:
+      namespace: "braintrust"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ai-gateway deployment when enabled
+    template: ai-gateway-deployment.yaml
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: braintrust-ai-gateway
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: ai-gateway
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/braintrust/gateway:v2.4.0
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COMPLETIONS_CACHE_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: braintrust-secrets
+                key: REDIS_URL
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_CACHE_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: braintrust-secrets
+                key: REDIS_URL
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BRAINSTORE_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: braintrust-secrets
+                key: BRAINSTORE_LICENSE_KEY
+
+  - it: should include extraEnvVars when provided
+    template: ai-gateway-deployment.yaml
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.extraEnvVars:
+        - name: DD_ENV
+          value: "production"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DD_ENV
+            value: "production"
+
+  - it: should include extraContainers when provided
+    template: ai-gateway-deployment.yaml
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.extraContainers:
+        - name: datadog-agent
+          image: public.ecr.aws/datadog/agent:7
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: datadog-agent
+
+  - it: should merge global and ai-gateway labels
+    template: ai-gateway-deployment.yaml
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.labels.component: "ai-gateway"
+      global.labels.environment: "production"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: metadata.labels.environment
+          value: production
+      - equal:
+          path: metadata.labels.component
+          value: ai-gateway

--- a/braintrust/tests/ai-gateway-service_test.yaml
+++ b/braintrust/tests/ai-gateway-service_test.yaml
@@ -1,0 +1,55 @@
+suite: test AI gateway service template
+templates:
+  - ai-gateway-service.yaml
+tests:
+  - it: should not render when ai-gateway is disabled
+    values:
+      - __fixtures__/base-values.yaml
+    release:
+      namespace: "braintrust"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ai-gateway service when enabled
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: braintrust-ai-gateway
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8080
+      - equal:
+          path: spec.selector.app
+          value: braintrust-ai-gateway
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should merge global and ai-gateway labels
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.labels.component: "ai-gateway"
+      global.labels.environment: "production"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: metadata.labels.environment
+          value: production
+      - equal:
+          path: metadata.labels.component
+          value: ai-gateway

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -301,7 +301,7 @@ tests:
           path: data.SKIP_PG_FOR_BRAINSTORE_OBJECTS
           value: "include:project_logs:abc123"
 
-  - it: should not include GATEWAY_URL when aiGateway is disabled
+  - it: should not include GATEWAY_URL when aiGateway useGateway is false
     values:
       - __fixtures__/base-values.yaml
     release:
@@ -310,11 +310,24 @@ tests:
       - isNull:
           path: data.GATEWAY_URL
 
-  - it: should set GATEWAY_URL when aiGateway is enabled
+  - it: should not include GATEWAY_URL when aiGateway is deployed but useGateway is false
     values:
       - __fixtures__/base-values.yaml
     set:
       aiGateway.enabled: true
+      aiGateway.useGateway: false
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isNull:
+          path: data.GATEWAY_URL
+
+  - it: should set GATEWAY_URL when aiGateway useGateway is true
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.useGateway: true
     release:
       namespace: "braintrust"
     asserts:
@@ -327,6 +340,7 @@ tests:
       - __fixtures__/base-values.yaml
     set:
       aiGateway.enabled: true
+      aiGateway.useGateway: true
       aiGateway.service.name: "custom-ai-gateway"
     release:
       namespace: "braintrust"

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -301,6 +301,40 @@ tests:
           path: data.SKIP_PG_FOR_BRAINSTORE_OBJECTS
           value: "include:project_logs:abc123"
 
+  - it: should not include GATEWAY_URL when aiGateway is disabled
+    values:
+      - __fixtures__/base-values.yaml
+    release:
+      namespace: "braintrust"
+    asserts:
+      - isNull:
+          path: data.GATEWAY_URL
+
+  - it: should set GATEWAY_URL when aiGateway is enabled
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.GATEWAY_URL
+          value: "http://braintrust-ai-gateway.braintrust:8080"
+
+  - it: should use custom aiGateway service name for GATEWAY_URL
+    values:
+      - __fixtures__/base-values.yaml
+    set:
+      aiGateway.enabled: true
+      aiGateway.service.name: "custom-ai-gateway"
+    release:
+      namespace: "braintrust"
+    asserts:
+      - equal:
+          path: data.GATEWAY_URL
+          value: "http://custom-ai-gateway.braintrust:8080"
+
   - it: should pass through exclude-style skipPgForBrainstoreObjects value
     values:
       - __fixtures__/base-values.yaml

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -163,8 +163,11 @@ api:
 
 # AI Gateway configuration (optional)
 # Deploys the Braintrust AI gateway service for LLM proxying and completions caching.
+# Recommended rollout: enabled=true first, wait for gateway pods to be ready, then useGateway=true.
 aiGateway:
   enabled: false
+  # Sets GATEWAY_URL on the API to route requests through the AI Gateway. Requires enabled=true.
+  useGateway: false
   name: "braintrust-ai-gateway"
   labels: {}
   podLabels: {}

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -192,8 +192,6 @@ aiGateway:
   braintrustAppUrl: "https://www.braintrust.dev"
   # Defaults to the in-cluster API service URL when empty.
   braintrustApiUrl: ""
-  # Defaults to {braintrustAppUrl}/api/pulse/otel when empty.
-  otlpHttpEndpoint: ""
   resources:
     requests:
       cpu: "2"

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -189,7 +189,8 @@ aiGateway:
   braintrustAppUrl: "https://www.braintrust.dev"
   # Defaults to the in-cluster API service URL when empty.
   braintrustApiUrl: ""
-  otlpHttpEndpoint: "https://www.braintrust.dev/api/pulse/otel"
+  # Defaults to {braintrustAppUrl}/api/pulse/otel when empty.
+  otlpHttpEndpoint: ""
   resources:
     requests:
       cpu: "2"

--- a/braintrust/values.yaml
+++ b/braintrust/values.yaml
@@ -7,7 +7,7 @@ global:
   namespace: "braintrust"
   namespaceAnnotations: {}
   labels: {}
-  # Control plane telemetry configuration (applies to both API and Brainstore)
+  # Control plane telemetry configuration (applies to API, Brainstore, and AI Gateway)
   # Available options (comma-separated):
   #   - status: Health check information (default)
   #   - metrics: System metrics (CPU/memory) and Braintrust-specific metrics like indexing lag (default)
@@ -158,6 +158,67 @@ api:
   healthServer:
     host: "0.0.0.0"
     port: "8001"
+  extraContainers: []
+  extraVolumes: []
+
+# AI Gateway configuration (optional)
+# Deploys the Braintrust AI gateway service for LLM proxying and completions caching.
+aiGateway:
+  enabled: false
+  name: "braintrust-ai-gateway"
+  labels: {}
+  podLabels: {}
+  annotations:
+    configmap: {}
+    deployment: {}
+    service: {}
+    pod: {}
+  replicas: 2
+  image:
+    repository: public.ecr.aws/braintrust/gateway
+    tag: v2.4.0
+    pullPolicy: IfNotPresent
+  service:
+    # Optional name for service object. If not specified (empty), aiGateway.name is used.
+    name: ""
+    type: ClusterIP
+    port: 8080
+    portName: http
+  # Optional cloud region identifier (e.g. us-east-1). Sets GATEWAY_REGION when provided.
+  region: ""
+  braintrustAppUrl: "https://www.braintrust.dev"
+  # Defaults to the in-cluster API service URL when empty.
+  braintrustApiUrl: ""
+  otlpHttpEndpoint: "https://www.braintrust.dev/api/pulse/otel"
+  resources:
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 8080
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 8080
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  extraEnvVars: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
   extraContainers: []
   extraVolumes: []
 


### PR DESCRIPTION
> [!IMPORTANT]
> The Braintrust Gateway is currently in beta at this time. Running it in a self-hosted data plane via this helm chart is new functionality that may see breaking changes in the near future.

This adds an optional deployment for the [Braintrust gateway](https://www.braintrust.dev/docs/deploy/gateway). The intent is to have an internal deployment of the gateway which the API and Brainstore can use when interacting with external providers.

## Testing

Added some basic unit test coverage. Deployed GCP self-hosted environment with `aiGateway.enabled: true` and did some basic smoke testing against the resulting k8s service.

### Rollout

To enable the AI Gateway for an existing deployment, a two-phase approach can be used to limit the window where requests might be routed to the AI Gateway before it's fully ready.

#### Phase 1 - deploy the gateway

Enable the AI Gateway deployment in your values file:

```yaml
aiGateway:
  enabled: true
```

Trigger a helm upgrade and leverage `--wait`. For example:

```sh
helm upgrade \
  --namespace braintrust \
  braintrust \
  oci://public.ecr.aws/braintrust/helm/braintrust \
  --version <x.y.z> \
  --values <your-values.yaml> \
  --wait \
  --timeout 5m
```
  
#### Phase 2 - route requests to the gateway

Update your values file:

```yaml
aiGateway:
  enabled: true
  useGateway: true
```

Trigger another helm deploy (see example `helm upgrade` command above). Relevant requests will now use the AI Gateway.