### PR TITLE
emit v3 legacy ids in py+ts sdk

### DIFF
--- a/braintrust/templates/api-configmap.yaml
+++ b/braintrust/templates/api-configmap.yaml
@@ -27,6 +27,8 @@ metadata:
 data:
   ORG_NAME: {{ $orgName | quote }}
   PRIMARY_ORG_NAME: {{ $primaryOrgName | quote }}
+  # emit v3 spans in py+ts sdks. remove this setting when v4 migration is complete
+  BRAINTRUST_LEGACY_IDS: "true"
   {{- with $allowedOrgIds }}
   ALLOWED_ORG_IDS: {{ . | quote }}
   {{- end }}

--- a/braintrust/tests/api-configmap_test.yaml
+++ b/braintrust/tests/api-configmap_test.yaml
@@ -20,6 +20,9 @@ tests:
           path: data.PRIMARY_ORG_NAME
           value: ""
       - equal:
+          path: data.BRAINTRUST_LEGACY_IDS
+          value: "true"
+      - equal:
           path: data.BRAINSTORE_ENABLED
           value: "true"
       - equal:


### PR DESCRIPTION
he py+ts SDKs by default emit v4 span components. This is fine because our backend already supports v4 span components.

However, pieces of the backend share code with the SDKs, so to be conservative we're setting this flag to tell the SDKs to behave as they did before.

This flag will be removed once we fully switch to v4.